### PR TITLE
Stp fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.22.0
 toolchain go1.22.6
 
 require (
-	github.com/davecgh/go-spew v1.1.1
 	github.com/hashicorp/terraform-plugin-docs v0.19.4
 	github.com/hashicorp/terraform-plugin-framework v1.12.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.13.0

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.0
 toolchain go1.22.6
 
 require (
+	github.com/davecgh/go-spew v1.1.1
 	github.com/hashicorp/terraform-plugin-docs v0.19.4
 	github.com/hashicorp/terraform-plugin-framework v1.12.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.13.0

--- a/internal/provider/model_meraki_switch_stp.go
+++ b/internal/provider/model_meraki_switch_stp.go
@@ -22,8 +22,11 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"sort"
 
 	"github.com/CiscoDevNet/terraform-provider-meraki/internal/provider/helpers"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/netascode/go-meraki"
@@ -74,6 +77,7 @@ func (data SwitchSTP) toBody(ctx context.Context, state SwitchSTP) string {
 				itemBody, _ = sjson.Set(itemBody, "stpPriority", item.StpPriority.ValueInt64())
 			}
 			if !item.Stacks.IsNull() {
+				tflog.Debug(ctx, "\n\n### STACKS NOT NULL\n\n")
 				var values []string
 				item.Stacks.ElementsAs(ctx, &values, false)
 				itemBody, _ = sjson.Set(itemBody, "stacks", values)
@@ -137,8 +141,6 @@ func (data *SwitchSTP) fromBody(ctx context.Context, res meraki.Res) {
 
 // End of section. //template:end fromBody
 
-// Section below is generated&owned by "gen/generator.go". //template:begin fromBodyPartial
-
 // fromBodyPartial reads values from a gjson.Result into a tfstate model. It ignores null attributes in order to
 // uncouple the provider from the exact values that the backend API might summon to replace nulls. (Such behavior might
 // easily change across versions of the backend API.) For List/Set/Map attributes, the func only updates the
@@ -149,40 +151,82 @@ func (data *SwitchSTP) fromBodyPartial(ctx context.Context, res meraki.Res) {
 	} else {
 		data.RstpEnabled = types.BoolNull()
 	}
-	{
-		l := len(res.Get("stpBridgePriority").Array())
-		tflog.Debug(ctx, fmt.Sprintf("stpBridgePriority array resizing from %d to %d", len(data.StpBridgePriority), l))
-		if len(data.StpBridgePriority) > l {
-			data.StpBridgePriority = data.StpBridgePriority[:l]
+	s := spew.Sdump(data)
+	tflog.Debug(ctx, "\n\n"+s+"\n\n")
+	priorities := map[int64]tempPriority{}
+	for i := 0; i < len(res.Get("stpBridgePriority").Array()); i++ {
+		priorityRes := res.Get(fmt.Sprintf("stpBridgePriority.%d", i))
+		s := spew.Sdump(priorityRes)
+		tflog.Debug(ctx, "\n\n"+s+"\n\n")
+		priority := priorityRes.Get("stpPriority").Int()
+		t := tempPriority{
+			stacks:         []string{},
+			switchProfiles: []string{},
+			switches:       []string{},
 		}
+		if p, ok := priorities[priority]; ok {
+			t = p
+		}
+		if value := priorityRes.Get("stacks"); value.Exists() {
+			for _, r := range value.Array() {
+				t.stacks = append(t.stacks, r.String())
+			}
+		}
+		if value := priorityRes.Get("switchProfiles"); value.Exists() {
+			for _, r := range value.Array() {
+				t.switchProfiles = append(t.switchProfiles, r.String())
+			}
+		}
+		if value := priorityRes.Get("switches"); value.Exists() {
+			for _, r := range value.Array() {
+				t.switches = append(t.switches, r.String())
+			}
+		}
+		priorities[priority] = t
 	}
-	for i := range data.StpBridgePriority {
-		parent := &data
-		data := (*parent).StpBridgePriority[i]
-		parentRes := &res
-		res := parentRes.Get(fmt.Sprintf("stpBridgePriority.%d", i))
-		if value := res.Get("stpPriority"); value.Exists() && !data.StpPriority.IsNull() {
-			data.StpPriority = types.Int64Value(value.Int())
-		} else {
-			data.StpPriority = types.Int64Null()
-		}
-		if value := res.Get("stacks"); value.Exists() && !data.Stacks.IsNull() {
-			data.Stacks = helpers.GetStringSet(value.Array())
-		} else {
-			data.Stacks = types.SetNull(types.StringType)
-		}
-		if value := res.Get("switchProfiles"); value.Exists() && !data.SwitchProfiles.IsNull() {
-			data.SwitchProfiles = helpers.GetStringSet(value.Array())
-		} else {
-			data.SwitchProfiles = types.SetNull(types.StringType)
-		}
-		if value := res.Get("switches"); value.Exists() && !data.Switches.IsNull() {
-			data.Switches = helpers.GetStringSet(value.Array())
-		} else {
-			data.Switches = types.SetNull(types.StringType)
-		}
-		(*parent).StpBridgePriority[i] = data
+
+	keys := make([]int64, 0, len(priorities))
+	for k := range priorities {
+		keys = append(keys, k)
 	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+
+	newStpBridgePriority := []SwitchSTPStpBridgePriority{}
+	for _, k := range keys {
+		newStacks := []attr.Value{}
+		for _, s := range priorities[k].stacks {
+			newStacks = append(newStacks, types.StringValue(s))
+		}
+		newSwitches := []attr.Value{}
+		for _, s := range priorities[k].switches {
+			newSwitches = append(newSwitches, types.StringValue(s))
+		}
+		newSwitchProfiles := []attr.Value{}
+		for _, s := range priorities[k].switchProfiles {
+			newSwitchProfiles = append(newSwitchProfiles, types.StringValue(s))
+		}
+		newStpBridgePriority = append(newStpBridgePriority, SwitchSTPStpBridgePriority{
+			StpPriority:    types.Int64Value(k),
+			Stacks:         setOrNull(types.SetValueMust(types.StringType, newStacks)),
+			Switches:       setOrNull(types.SetValueMust(types.StringType, newSwitches)),
+			SwitchProfiles: setOrNull(types.SetValueMust(types.StringType, newSwitchProfiles)),
+		})
+	}
+	tflog.Debug(ctx, "\n\n"+spew.Sdump(newStpBridgePriority)+"\n\n")
+	data.StpBridgePriority = newStpBridgePriority
+
+	tflog.Debug(ctx, "\n\nFROM PARTIAL\n"+spew.Sdump(data)+"\n\n")
 }
 
-// End of section. //template:end fromBodyPartial
+func setOrNull(s types.Set) types.Set {
+	if len(s.Elements()) == 0 {
+		return types.SetNull(types.StringType)
+	}
+	return s
+}
+
+type tempPriority struct {
+	stacks         []string
+	switchProfiles []string
+	switches       []string
+}

--- a/internal/provider/model_meraki_switch_stp.go
+++ b/internal/provider/model_meraki_switch_stp.go
@@ -157,7 +157,7 @@ func (data *SwitchSTP) fromBodyPartial(ctx context.Context, res meraki.Res) {
 		}
 	}
 	priorities := map[int64]tempPriority{}
-	for i := 0; i < len(res.Get("stpBridgePriority").Array()); i++ {
+	for i := range res.Get("stpBridgePriority").Array() {
 		priorityRes := res.Get(fmt.Sprintf("stpBridgePriority.%d", i))
 		priority := priorityRes.Get("stpPriority").Int()
 		t := tempPriority{


### PR DESCRIPTION
This is a workaround for weird API behavior when it comes to switch STP. The data is essentially a map where the key is the priority and the value is a tuple (stacks, switchProfiles, switches). But the API implements this as a list and sometimes returns multiple entries with the same priority which confuses the provider because it thinks that changes were made. In particular, the scenario that I have observed:

1. posted a singular object with switches, profiles and stacks
2. observed multiple objects returned with switches, profiles and stacks separately but _the same priority_
3. provider thinks changes were made and there is an idempotency inconsistency

The fix essentially converts the whole input data into the map, merging all the data as necessary and only then exposes the data to Terraform. No changes were necessary when converting Terraform data to the API.