### PR TITLE
fix l3 firewall rules delete behavior

### DIFF
--- a/internal/provider/resource_meraki_appliance_l3_firewall_rules.go
+++ b/internal/provider/resource_meraki_appliance_l3_firewall_rules.go
@@ -251,8 +251,6 @@ func (r *ApplianceL3FirewallRulesResource) Update(ctx context.Context, req resou
 
 // End of section. //template:end update
 
-// Section below is generated&owned by "gen/generator.go". //template:begin delete
-
 func (r *ApplianceL3FirewallRulesResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var state ApplianceL3FirewallRules
 
@@ -264,12 +262,19 @@ func (r *ApplianceL3FirewallRulesResource) Delete(ctx context.Context, req resou
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Delete", state.Id.ValueString()))
 
+	state.Rules = []ApplianceL3FirewallRulesRules{}
+
+	body := state.toBody(ctx, state)
+	res, err := r.client.Put(state.getPath(), body)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to delete object (PUT), got error: %s, %s", err, res.String()))
+		return
+	}
+
 	tflog.Debug(ctx, fmt.Sprintf("%s: Delete finished successfully", state.Id.ValueString()))
 
 	resp.State.RemoveResource(ctx)
 }
-
-// End of section. //template:end delete
 
 // Section below is generated&owned by "gen/generator.go". //template:begin import
 func (r *ApplianceL3FirewallRulesResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {


### PR DESCRIPTION
Fix for #43.

The delete behavior was no op (as usually is with singleton resources). This PR adds an additional request on delete:
```
2025/02/05 14:45:59 REQUEST --------------------------
2025/02/05 14:45:59 PUT https://api.meraki.com/api/v1/networks/L_709316941310888184/appliance/firewall/l3FirewallRules
2025/02/05 14:45:59 User-Agent: [go-meraki netascode]
2025/02/05 14:45:59 Content-Type: [application/json]
2025/02/05 14:45:59 Accept: [application/json]
2025/02/05 14:45:59 Authorization: ****
2025/02/05 14:45:59 --------------------------
2025/02/05 14:45:59 {
2025/02/05 14:45:59   "rules": []
2025/02/05 14:45:59 }
2025/02/05 14:46:00 RESPONSE 200 --------------------------
2025/02/05 14:46:00 {
2025/02/05 14:46:00   "rules": [
2025/02/05 14:46:00     {
2025/02/05 14:46:00       "comment": "Default rule",
2025/02/05 14:46:00       "destCidr": "Any",
2025/02/05 14:46:00       "destPort": "Any",
2025/02/05 14:46:00       "policy": "allow",
2025/02/05 14:46:00       "protocol": "Any",
2025/02/05 14:46:00       "srcCidr": "Any",
2025/02/05 14:46:00       "srcPort": "Any",
2025/02/05 14:46:00       "syslogEnabled": false
2025/02/05 14:46:00     }
2025/02/05 14:46:00   ]
2025/02/05 14:46:00 }
2025/02/05 14:46:00 --------------------------
```
This deletes all rules that were previously configured.