### PR TITLE
early access features opt in: Fix idempotency

### DIFF
--- a/docs/resources/organization_early_access_features_opt_in.md
+++ b/docs/resources/organization_early_access_features_opt_in.md
@@ -14,8 +14,9 @@ This resource can manage the `Organization Early Access Features Opt In` configu
 
 ```terraform
 resource "meraki_organization_early_access_features_opt_in" "example" {
-  organization_id = "123456"
-  short_name      = "has_cloud_pcap_support"
+  organization_id         = "123456"
+  short_name              = "has_mx_no_nat_early_access"
+  limit_scope_to_networks = ["N_12345"]
 }
 ```
 

--- a/examples/resources/meraki_organization_early_access_features_opt_in/resource.tf
+++ b/examples/resources/meraki_organization_early_access_features_opt_in/resource.tf
@@ -1,4 +1,5 @@
 resource "meraki_organization_early_access_features_opt_in" "example" {
-  organization_id = "123456"
-  short_name      = "has_cloud_pcap_support"
+  organization_id         = "123456"
+  short_name              = "has_mx_no_nat_early_access"
+  limit_scope_to_networks = ["N_12345"]
 }

--- a/gen/definitions/organization_early_access_features_opt_in.yaml
+++ b/gen/definitions/organization_early_access_features_opt_in.yaml
@@ -3,7 +3,7 @@ spec_endpoint: /organizations/{organizationId}/earlyAccess/features/optIns/{optI
 rest_endpoint: /organizations/%v/earlyAccess/features/optIns
 bulk_data_source: true
 doc_category: Organizations
-test_variables: [test_org]
+test_variables: [test_org, test_network]
 attributes:
   - tf_name: organization_id
     type: String
@@ -15,14 +15,19 @@ attributes:
     type: String
     mandatory: true
     description: Short name of the early access feature
-    example: has_cloud_pcap_support
+    example: has_mx_no_nat_early_access
   - model_name: limitScopeToNetworks
     type: List
     element_type: String
-    exclude_test: true
     description: A list of network IDs to apply the opt-in to
     example: N_12345
+    test_value: '[meraki_network.test.id]'
 test_prerequisites: |
   data "meraki_organization" "test" {
     name = var.test_org
+  }
+  resource "meraki_network" "test" {
+    organization_id = data.meraki_organization.test.id
+    name            = var.test_network
+    product_types   = ["appliance"]
   }

--- a/internal/provider/data_source_meraki_organization_early_access_features_opt_in_test.go
+++ b/internal/provider/data_source_meraki_organization_early_access_features_opt_in_test.go
@@ -30,11 +30,11 @@ import (
 // Section below is generated&owned by "gen/generator.go". //template:begin testAccDataSource
 
 func TestAccDataSourceMerakiOrganizationEarlyAccessFeaturesOptIn(t *testing.T) {
-	if os.Getenv("TF_VAR_test_org") == "" {
-		t.Skip("skipping test, set environment variable TF_VAR_test_org")
+	if os.Getenv("TF_VAR_test_org") == "" || os.Getenv("TF_VAR_test_network") == "" {
+		t.Skip("skipping test, set environment variable TF_VAR_test_org and TF_VAR_test_network")
 	}
 	var checks []resource.TestCheckFunc
-	checks = append(checks, resource.TestCheckResourceAttr("data.meraki_organization_early_access_features_opt_in.test", "short_name", "has_cloud_pcap_support"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.meraki_organization_early_access_features_opt_in.test", "short_name", "has_mx_no_nat_early_access"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -53,8 +53,14 @@ func TestAccDataSourceMerakiOrganizationEarlyAccessFeaturesOptIn(t *testing.T) {
 
 const testAccDataSourceMerakiOrganizationEarlyAccessFeaturesOptInPrerequisitesConfig = `
 variable "test_org" {}
+variable "test_network" {}
 data "meraki_organization" "test" {
   name = var.test_org
+}
+resource "meraki_network" "test" {
+  organization_id = data.meraki_organization.test.id
+  name            = var.test_network
+  product_types   = ["appliance"]
 }
 
 `
@@ -66,7 +72,8 @@ data "meraki_organization" "test" {
 func testAccDataSourceMerakiOrganizationEarlyAccessFeaturesOptInConfig() string {
 	config := `resource "meraki_organization_early_access_features_opt_in" "test" {` + "\n"
 	config += `  organization_id = data.meraki_organization.test.id` + "\n"
-	config += `  short_name = "has_cloud_pcap_support"` + "\n"
+	config += `  short_name = "has_mx_no_nat_early_access"` + "\n"
+	config += `  limit_scope_to_networks = [meraki_network.test.id]` + "\n"
 	config += `}` + "\n"
 
 	config += `

--- a/internal/provider/data_source_meraki_organization_early_access_features_opt_ins_test.go
+++ b/internal/provider/data_source_meraki_organization_early_access_features_opt_ins_test.go
@@ -30,8 +30,8 @@ import (
 // Section below is generated&owned by "gen/generator.go". //template:begin testAccDataSource
 
 func TestAccDataSourceMerakiOrganizationEarlyAccessFeaturesOptIns(t *testing.T) {
-	if os.Getenv("TF_VAR_test_org") == "" {
-		t.Skip("skipping test, set environment variable TF_VAR_test_org")
+	if os.Getenv("TF_VAR_test_org") == "" || os.Getenv("TF_VAR_test_network") == "" {
+		t.Skip("skipping test, set environment variable TF_VAR_test_org and TF_VAR_test_network")
 	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -50,8 +50,14 @@ func TestAccDataSourceMerakiOrganizationEarlyAccessFeaturesOptIns(t *testing.T) 
 
 const testAccDataSourceMerakiOrganizationEarlyAccessFeaturesOptInsPrerequisitesConfig = `
 variable "test_org" {}
+variable "test_network" {}
 data "meraki_organization" "test" {
   name = var.test_org
+}
+resource "meraki_network" "test" {
+  organization_id = data.meraki_organization.test.id
+  name            = var.test_network
+  product_types   = ["appliance"]
 }
 
 `

--- a/internal/provider/helpers/utils.go
+++ b/internal/provider/helpers/utils.go
@@ -43,6 +43,18 @@ func GetStringList(result []gjson.Result) types.List {
 	return types.ListValueMust(types.StringType, v)
 }
 
+func GetStringListFromMapList(result []gjson.Result, key string) types.List {
+	v := make([]attr.Value, len(result))
+	for r := range result {
+		if value := result[r].Get(key); value.Exists() && value.Value() != nil {
+			v[r] = types.StringValue(value.String())
+		} else {
+			v[r] = types.StringNull()
+		}
+	}
+	return types.ListValueMust(types.StringType, v)
+}
+
 func GetInt64List(result []gjson.Result) types.List {
 	v := make([]attr.Value, len(result))
 	for r := range result {

--- a/internal/provider/model_meraki_organization_early_access_features_opt_in.go
+++ b/internal/provider/model_meraki_organization_early_access_features_opt_in.go
@@ -67,8 +67,6 @@ func (data OrganizationEarlyAccessFeaturesOptIn) toBody(ctx context.Context, sta
 
 // End of section. //template:end toBody
 
-// Section below is generated&owned by "gen/generator.go". //template:begin fromBody
-
 func (data *OrganizationEarlyAccessFeaturesOptIn) fromBody(ctx context.Context, res meraki.Res) {
 	if value := res.Get("shortName"); value.Exists() && value.Value() != nil {
 		data.ShortName = types.StringValue(value.String())
@@ -76,15 +74,11 @@ func (data *OrganizationEarlyAccessFeaturesOptIn) fromBody(ctx context.Context, 
 		data.ShortName = types.StringNull()
 	}
 	if value := res.Get("limitScopeToNetworks"); value.Exists() && value.Value() != nil {
-		data.LimitScopeToNetworks = helpers.GetStringList(value.Array())
+		data.LimitScopeToNetworks = helpers.GetStringListFromMapList(value.Array(), "id")
 	} else {
 		data.LimitScopeToNetworks = types.ListNull(types.StringType)
 	}
 }
-
-// End of section. //template:end fromBody
-
-// Section below is generated&owned by "gen/generator.go". //template:begin fromBodyPartial
 
 // fromBodyPartial reads values from a gjson.Result into a tfstate model. It ignores null attributes in order to
 // uncouple the provider from the exact values that the backend API might summon to replace nulls. (Such behavior might
@@ -97,13 +91,11 @@ func (data *OrganizationEarlyAccessFeaturesOptIn) fromBodyPartial(ctx context.Co
 		data.ShortName = types.StringNull()
 	}
 	if value := res.Get("limitScopeToNetworks"); value.Exists() && !data.LimitScopeToNetworks.IsNull() {
-		data.LimitScopeToNetworks = helpers.GetStringList(value.Array())
+		data.LimitScopeToNetworks = helpers.GetStringListFromMapList(value.Array(), "id")
 	} else {
 		data.LimitScopeToNetworks = types.ListNull(types.StringType)
 	}
 }
-
-// End of section. //template:end fromBodyPartial
 
 // Section below is generated&owned by "gen/generator.go". //template:begin fromBodyUnknowns
 

--- a/internal/provider/resource_meraki_organization_early_access_features_opt_in_test.go
+++ b/internal/provider/resource_meraki_organization_early_access_features_opt_in_test.go
@@ -32,11 +32,11 @@ import (
 // Section below is generated&owned by "gen/generator.go". //template:begin testAcc
 
 func TestAccMerakiOrganizationEarlyAccessFeaturesOptIn(t *testing.T) {
-	if os.Getenv("TF_VAR_test_org") == "" {
-		t.Skip("skipping test, set environment variable TF_VAR_test_org")
+	if os.Getenv("TF_VAR_test_org") == "" || os.Getenv("TF_VAR_test_network") == "" {
+		t.Skip("skipping test, set environment variable TF_VAR_test_org and TF_VAR_test_network")
 	}
 	var checks []resource.TestCheckFunc
-	checks = append(checks, resource.TestCheckResourceAttr("meraki_organization_early_access_features_opt_in.test", "short_name", "has_cloud_pcap_support"))
+	checks = append(checks, resource.TestCheckResourceAttr("meraki_organization_early_access_features_opt_in.test", "short_name", "has_mx_no_nat_early_access"))
 
 	var steps []resource.TestStep
 	if os.Getenv("SKIP_MINIMUM_TEST") == "" {
@@ -84,8 +84,14 @@ func merakiOrganizationEarlyAccessFeaturesOptInImportStateIdFunc(resourceName st
 
 const testAccMerakiOrganizationEarlyAccessFeaturesOptInPrerequisitesConfig = `
 variable "test_org" {}
+variable "test_network" {}
 data "meraki_organization" "test" {
   name = var.test_org
+}
+resource "meraki_network" "test" {
+  organization_id = data.meraki_organization.test.id
+  name            = var.test_network
+  product_types   = ["appliance"]
 }
 
 `
@@ -97,7 +103,7 @@ data "meraki_organization" "test" {
 func testAccMerakiOrganizationEarlyAccessFeaturesOptInConfig_minimum() string {
 	config := `resource "meraki_organization_early_access_features_opt_in" "test" {` + "\n"
 	config += `  organization_id = data.meraki_organization.test.id` + "\n"
-	config += `  short_name = "has_cloud_pcap_support"` + "\n"
+	config += `  short_name = "has_mx_no_nat_early_access"` + "\n"
 	config += `}` + "\n"
 	return config
 }
@@ -109,7 +115,8 @@ func testAccMerakiOrganizationEarlyAccessFeaturesOptInConfig_minimum() string {
 func testAccMerakiOrganizationEarlyAccessFeaturesOptInConfig_all() string {
 	config := `resource "meraki_organization_early_access_features_opt_in" "test" {` + "\n"
 	config += `  organization_id = data.meraki_organization.test.id` + "\n"
-	config += `  short_name = "has_cloud_pcap_support"` + "\n"
+	config += `  short_name = "has_mx_no_nat_early_access"` + "\n"
+	config += `  limit_scope_to_networks = [meraki_network.test.id]` + "\n"
 	config += `}` + "\n"
 	return config
 }


### PR DESCRIPTION
With limit_scope_to_networks specified,
a subsequent "terraform apply" shows a required change, as the API returns a list of maps like
`[{"id": "L_1234", "name": "net name"}]`
instead of the list of strings like `["L_1234"]`
which it [takes in the request](https://developer.cisco.com/meraki/api-v1/update-organization-adaptive-policy-policy/):
```
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.meraki.meraki_organization_early_access_features_opt_in.organizations_early_access_features_opt_in["Dev-WB/has_mx_no_nat_early_access"] will be updated in-place
  ~ resource "meraki_organization_early_access_features_opt_in" "organizations_early_access_features_opt_in" {
        id                      = "3859584880656530524"
      ~ limit_scope_to_networks = [
          ~ jsonencode(
                {
                  - id   = "L_3859584880656521123"
                  - name = "netascode-network-01"
                }
            ) -> "L_3859584880656521123",
        ]
        # (2 unchanged attributes hidden)
    }
```

As a workaround,
change `fromBody()` manually to convert the list of maps back to the list of strings -
there does not seem to be an existing option in the definition for the generator to do that automatically.