### PR TITLE
Fix deletion for single-array-only resources

### DIFF
--- a/gen/definitions/appliance_connectivity_monitoring_destinations.yaml
+++ b/gen/definitions/appliance_connectivity_monitoring_destinations.yaml
@@ -17,6 +17,7 @@ attributes:
     type: List
     mandatory: true
     description: The list of connectivity monitoring destinations
+    destroy_value: '[]interface{}{}'
     attributes:
       - model_name: default
         type: Bool

--- a/gen/definitions/appliance_firewall_multicast_forwarding.yaml
+++ b/gen/definitions/appliance_firewall_multicast_forwarding.yaml
@@ -21,6 +21,7 @@ attributes:
     type: List
     mandatory: true
     description: Static multicast forwarding rules. Pass an empty array to clear all rules.
+    destroy_value: '[]interface{}{}'
     attributes:
       - model_name: address
         type: String

--- a/gen/definitions/appliance_organization_security_intrusion.yaml
+++ b/gen/definitions/appliance_organization_security_intrusion.yaml
@@ -18,6 +18,7 @@ attributes:
     type: List
     mandatory: true
     description: Sets a list of specific SNORT signatures to allow
+    destroy_value: '[]interface{}{}'
     attributes:
       - model_name: message
         type: String

--- a/gen/definitions/appliance_third_party_vpn_peers.yaml
+++ b/gen/definitions/appliance_third_party_vpn_peers.yaml
@@ -17,6 +17,7 @@ attributes:
     type: List
     mandatory: true
     description: The list of VPN peers
+    destroy_value: '[]interface{}{}'
     attributes:
       - model_name: ikeVersion
         type: String

--- a/gen/definitions/cellular_gateway_connectivity_monitoring_destinations.yaml
+++ b/gen/definitions/cellular_gateway_connectivity_monitoring_destinations.yaml
@@ -17,6 +17,7 @@ attributes:
     type: List
     mandatory: true
     description: The list of connectivity monitoring destinations
+    destroy_value: '[]interface{}{}'
     attributes:
       - model_name: default
         type: Bool

--- a/gen/definitions/network_syslog_servers.yaml
+++ b/gen/definitions/network_syslog_servers.yaml
@@ -17,6 +17,7 @@ attributes:
     type: List
     mandatory: true
     description: A list of the syslog servers for this network
+    destroy_value: '[]interface{}{}'
     attributes:
       - model_name: host
         type: String

--- a/gen/definitions/sensor_relationships.yaml
+++ b/gen/definitions/sensor_relationships.yaml
@@ -18,6 +18,7 @@ attributes:
     type: List
     data_path: [livestream]
     description: An array of the related devices for the role
+    destroy_value: '[]interface{}{}'
     attributes:
       - model_name: serial
         type: String

--- a/gen/definitions/switch_access_control_lists.yaml
+++ b/gen/definitions/switch_access_control_lists.yaml
@@ -18,6 +18,7 @@ attributes:
     mandatory: true
     description: An ordered array of the access control list rules (not including the default rule). An empty array will clear the rules.
     ordered_list: true
+    destroy_value: '[]interface{}{}'
     attributes:
       - model_name: comment
         type: String

--- a/gen/definitions/switch_dscp_to_cos_mappings.yaml
+++ b/gen/definitions/switch_dscp_to_cos_mappings.yaml
@@ -17,6 +17,7 @@ attributes:
     type: List
     mandatory: true
     description: An array of DSCP to CoS mappings. An empty array will reset the mappings to default.
+    destroy_value: '[]interface{}{}'
     attributes:
       - model_name: cos
         type: Int64

--- a/internal/provider/model_meraki_appliance_connectivity_monitoring_destinations.go
+++ b/internal/provider/model_meraki_appliance_connectivity_monitoring_destinations.go
@@ -190,6 +190,7 @@ func (data *ApplianceConnectivityMonitoringDestinations) fromBodyUnknowns(ctx co
 
 func (data ApplianceConnectivityMonitoringDestinations) toDestroyBody(ctx context.Context) string {
 	body := ""
+	body, _ = sjson.Set(body, "destinations", []interface{}{})
 	return body
 }
 

--- a/internal/provider/model_meraki_appliance_firewall_multicast_forwarding.go
+++ b/internal/provider/model_meraki_appliance_firewall_multicast_forwarding.go
@@ -193,6 +193,7 @@ func (data *ApplianceFirewallMulticastForwarding) fromBodyUnknowns(ctx context.C
 
 func (data ApplianceFirewallMulticastForwarding) toDestroyBody(ctx context.Context) string {
 	body := ""
+	body, _ = sjson.Set(body, "rules", []interface{}{})
 	return body
 }
 

--- a/internal/provider/model_meraki_appliance_organization_security_intrusion.go
+++ b/internal/provider/model_meraki_appliance_organization_security_intrusion.go
@@ -176,6 +176,7 @@ func (data *ApplianceOrganizationSecurityIntrusion) fromBodyUnknowns(ctx context
 
 func (data ApplianceOrganizationSecurityIntrusion) toDestroyBody(ctx context.Context) string {
 	body := ""
+	body, _ = sjson.Set(body, "allowedRules", []interface{}{})
 	return body
 }
 

--- a/internal/provider/model_meraki_appliance_third_party_vpn_peers.go
+++ b/internal/provider/model_meraki_appliance_third_party_vpn_peers.go
@@ -433,6 +433,7 @@ func (data *ApplianceThirdPartyVPNPeers) fromBodyUnknowns(ctx context.Context, r
 
 func (data ApplianceThirdPartyVPNPeers) toDestroyBody(ctx context.Context) string {
 	body := ""
+	body, _ = sjson.Set(body, "peers", []interface{}{})
 	return body
 }
 

--- a/internal/provider/model_meraki_cellular_gateway_connectivity_monitoring_destinations.go
+++ b/internal/provider/model_meraki_cellular_gateway_connectivity_monitoring_destinations.go
@@ -191,6 +191,7 @@ func (data *CellularGatewayConnectivityMonitoringDestinations) fromBodyUnknowns(
 
 func (data CellularGatewayConnectivityMonitoringDestinations) toDestroyBody(ctx context.Context) string {
 	body := ""
+	body, _ = sjson.Set(body, "destinations", []interface{}{})
 	return body
 }
 

--- a/internal/provider/model_meraki_network_syslog_servers.go
+++ b/internal/provider/model_meraki_network_syslog_servers.go
@@ -194,6 +194,7 @@ func (data *NetworkSyslogServers) fromBodyUnknowns(ctx context.Context, res mera
 
 func (data NetworkSyslogServers) toDestroyBody(ctx context.Context) string {
 	body := ""
+	body, _ = sjson.Set(body, "servers", []interface{}{})
 	return body
 }
 

--- a/internal/provider/model_meraki_sensor_relationships.go
+++ b/internal/provider/model_meraki_sensor_relationships.go
@@ -162,6 +162,7 @@ func (data *SensorRelationships) fromBodyUnknowns(ctx context.Context, res merak
 
 func (data SensorRelationships) toDestroyBody(ctx context.Context) string {
 	body := ""
+	body, _ = sjson.Set(body, "livestream.relatedDevices", []interface{}{})
 	return body
 }
 

--- a/internal/provider/model_meraki_switch_access_control_lists.go
+++ b/internal/provider/model_meraki_switch_access_control_lists.go
@@ -252,6 +252,7 @@ func (data *SwitchAccessControlLists) fromBodyUnknowns(ctx context.Context, res 
 
 func (data SwitchAccessControlLists) toDestroyBody(ctx context.Context) string {
 	body := ""
+	body, _ = sjson.Set(body, "rules", []interface{}{})
 	return body
 }
 

--- a/internal/provider/model_meraki_switch_dscp_to_cos_mappings.go
+++ b/internal/provider/model_meraki_switch_dscp_to_cos_mappings.go
@@ -191,6 +191,7 @@ func (data *SwitchDSCPToCoSMappings) fromBodyUnknowns(ctx context.Context, res m
 
 func (data SwitchDSCPToCoSMappings) toDestroyBody(ctx context.Context) string {
 	body := ""
+	body, _ = sjson.Set(body, "mappings", []interface{}{})
 	return body
 }
 

--- a/internal/provider/resource_meraki_appliance_connectivity_monitoring_destinations.go
+++ b/internal/provider/resource_meraki_appliance_connectivity_monitoring_destinations.go
@@ -231,6 +231,12 @@ func (r *ApplianceConnectivityMonitoringDestinationsResource) Delete(ctx context
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Delete", state.Id.ValueString()))
+	body := state.toDestroyBody(ctx)
+	res, err := r.client.Put(state.getPath(), body)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (PUT), got error: %s, %s", err, res.String()))
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Delete finished successfully", state.Id.ValueString()))
 

--- a/internal/provider/resource_meraki_appliance_firewall_multicast_forwarding.go
+++ b/internal/provider/resource_meraki_appliance_firewall_multicast_forwarding.go
@@ -253,6 +253,12 @@ func (r *ApplianceFirewallMulticastForwardingResource) Delete(ctx context.Contex
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Delete", state.Id.ValueString()))
+	body := state.toDestroyBody(ctx)
+	res, err := r.client.Put(state.getPath(), body)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (PUT), got error: %s, %s", err, res.String()))
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Delete finished successfully", state.Id.ValueString()))
 

--- a/internal/provider/resource_meraki_appliance_organization_security_intrusion.go
+++ b/internal/provider/resource_meraki_appliance_organization_security_intrusion.go
@@ -227,6 +227,12 @@ func (r *ApplianceOrganizationSecurityIntrusionResource) Delete(ctx context.Cont
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Delete", state.Id.ValueString()))
+	body := state.toDestroyBody(ctx)
+	res, err := r.client.Put(state.getPath(), body)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (PUT), got error: %s, %s", err, res.String()))
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Delete finished successfully", state.Id.ValueString()))
 

--- a/internal/provider/resource_meraki_appliance_third_party_vpn_peers.go
+++ b/internal/provider/resource_meraki_appliance_third_party_vpn_peers.go
@@ -310,6 +310,12 @@ func (r *ApplianceThirdPartyVPNPeersResource) Delete(ctx context.Context, req re
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Delete", state.Id.ValueString()))
+	body := state.toDestroyBody(ctx)
+	res, err := r.client.Put(state.getPath(), body)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (PUT), got error: %s, %s", err, res.String()))
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Delete finished successfully", state.Id.ValueString()))
 

--- a/internal/provider/resource_meraki_cellular_gateway_connectivity_monitoring_destinations.go
+++ b/internal/provider/resource_meraki_cellular_gateway_connectivity_monitoring_destinations.go
@@ -231,6 +231,12 @@ func (r *CellularGatewayConnectivityMonitoringDestinationsResource) Delete(ctx c
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Delete", state.Id.ValueString()))
+	body := state.toDestroyBody(ctx)
+	res, err := r.client.Put(state.getPath(), body)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (PUT), got error: %s, %s", err, res.String()))
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Delete finished successfully", state.Id.ValueString()))
 

--- a/internal/provider/resource_meraki_network_syslog_servers.go
+++ b/internal/provider/resource_meraki_network_syslog_servers.go
@@ -233,6 +233,12 @@ func (r *NetworkSyslogServersResource) Delete(ctx context.Context, req resource.
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Delete", state.Id.ValueString()))
+	body := state.toDestroyBody(ctx)
+	res, err := r.client.Put(state.getPath(), body)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (PUT), got error: %s, %s", err, res.String()))
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Delete finished successfully", state.Id.ValueString()))
 

--- a/internal/provider/resource_meraki_sensor_relationships.go
+++ b/internal/provider/resource_meraki_sensor_relationships.go
@@ -223,6 +223,12 @@ func (r *SensorRelationshipsResource) Delete(ctx context.Context, req resource.D
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Delete", state.Id.ValueString()))
+	body := state.toDestroyBody(ctx)
+	res, err := r.client.Put(state.getPath(), body)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (PUT), got error: %s, %s", err, res.String()))
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Delete finished successfully", state.Id.ValueString()))
 

--- a/internal/provider/resource_meraki_switch_access_control_lists.go
+++ b/internal/provider/resource_meraki_switch_access_control_lists.go
@@ -266,6 +266,12 @@ func (r *SwitchAccessControlListsResource) Delete(ctx context.Context, req resou
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Delete", state.Id.ValueString()))
+	body := state.toDestroyBody(ctx)
+	res, err := r.client.Put(state.getPath(), body)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (PUT), got error: %s, %s", err, res.String()))
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Delete finished successfully", state.Id.ValueString()))
 

--- a/internal/provider/resource_meraki_switch_dscp_to_cos_mappings.go
+++ b/internal/provider/resource_meraki_switch_dscp_to_cos_mappings.go
@@ -231,6 +231,12 @@ func (r *SwitchDSCPToCoSMappingsResource) Delete(ctx context.Context, req resour
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Delete", state.Id.ValueString()))
+	body := state.toDestroyBody(ctx)
+	res, err := r.client.Put(state.getPath(), body)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (PUT), got error: %s, %s", err, res.String()))
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Delete finished successfully", state.Id.ValueString()))
 


### PR DESCRIPTION
Singleton resources (ones without a DELETE endpoint) don't do anything on delete,
leaving the infrastructure still configured.
Aside from being unexpected,
this also sometimes blocks deletion of other resources (like in https://github.com/CiscoDevNet/terraform-provider-meraki/issues/82).

Some resources (mostly ones with a single "rules" list attribute) were changed to instead do a PUT with an empty list, fixing the issue for those resources.

Do that for the rest of such resources
(ones with a single attribute that is a list of maps).

Note that 79 resources that do nothing on delete
still remain after this change.
The issue will have to be documented
and the resources fixed manually on a case-by-case basis by inferring the expected behavior from the UI.

TODO: Test this.