### PR TITLE
switch_port: Unset access policy, adaptive policy, profile on deletion

### DIFF
--- a/gen/definitions/switch_port.yaml
+++ b/gen/definitions/switch_port.yaml
@@ -28,11 +28,13 @@ attributes:
     description: The type of the access policy of the switch port. Only applicable to access ports. Can be one of `Open`, `Custom access policy`, `MAC allow list` or `Sticky MAC allow list`.
     example: Sticky MAC allow list
     enum_values: [Custom access policy, MAC allow list, Open, Sticky MAC allow list]
+    destroy_value: '"Open"'
   - model_name: adaptivePolicyGroupId
     type: String
     exclude_test: true
     description: The adaptive policy group ID that will be used to tag traffic through this switch port. This ID must pre-exist during the configuration, else needs to be created using adaptivePolicy/groups API. Cannot be applied to a port on a switch bound to profile.
     example: "123"
+    destroy_value: nil
   - model_name: allowedVlans
     type: String
     description: The VLANs allowed on the switch port. Only applicable to trunk ports.
@@ -129,6 +131,7 @@ attributes:
     data_path: [profile]
     description: When enabled, override this port`s configuration with a port profile.
     example: "false"
+    destroy_value: "false"
   - model_name: id
     type: String
     data_path: [profile]

--- a/internal/provider/model_meraki_switch_port.go
+++ b/internal/provider/model_meraki_switch_port.go
@@ -497,14 +497,17 @@ func (data *SwitchPort) fromBodyUnknowns(ctx context.Context, res meraki.Res) {
 
 // End of section. //template:end fromBodyUnknowns
 
-// Section below is generated&owned by "gen/generator.go". //template:begin toDestroyBody
-
 func (data SwitchPort) toDestroyBody(ctx context.Context) string {
 	body := ""
 	body, _ = sjson.Set(body, "accessPolicyType", "Open")
-	body, _ = sjson.Set(body, "adaptivePolicyGroupId", nil)
+	if !data.AdaptivePolicyGroupId.IsNull() {
+		// This can fail with "Adaptive Policy is not enabled in this network"
+		// if meraki_organization_adaptive_policy_settings resource
+		// does not have adaptive policy enabled for this network.
+		// Unset adaptive policy group ID only if it was already set
+		// (which could only be done if adaptive policy *is* enabled on the network first).
+		body, _ = sjson.Set(body, "adaptivePolicyGroupId", nil)
+	}
 	body, _ = sjson.Set(body, "profile.enabled", false)
 	return body
 }
-
-// End of section. //template:end toDestroyBody

--- a/internal/provider/model_meraki_switch_port.go
+++ b/internal/provider/model_meraki_switch_port.go
@@ -501,6 +501,9 @@ func (data *SwitchPort) fromBodyUnknowns(ctx context.Context, res meraki.Res) {
 
 func (data SwitchPort) toDestroyBody(ctx context.Context) string {
 	body := ""
+	body, _ = sjson.Set(body, "accessPolicyType", "Open")
+	body, _ = sjson.Set(body, "adaptivePolicyGroupId", nil)
+	body, _ = sjson.Set(body, "profile.enabled", false)
 	return body
 }
 

--- a/internal/provider/resource_meraki_switch_port.go
+++ b/internal/provider/resource_meraki_switch_port.go
@@ -352,6 +352,12 @@ func (r *SwitchPortResource) Delete(ctx context.Context, req resource.DeleteRequ
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Beginning Delete", state.Id.ValueString()))
+	body := state.toDestroyBody(ctx)
+	res, err := r.client.Put(state.getPath(), body)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to configure object (PUT), got error: %s, %s", err, res.String()))
+		return
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Delete finished successfully", state.Id.ValueString()))
 


### PR DESCRIPTION
If `access_policy_number` refers to an access policy,
deletion of the access policy is blocked
even after deleting the switch port:
```
│ Error: Client Error
│
│ Failed to delete object (DELETE), got error: HTTP Request failed: StatusCode 400, {"errors":["This access policy is in use by 3 ports. An access policy can only
│ be removed if it is not in use."]}
```

If `adaptive_policy_group_id` refers to an adaptive policy group,
deletion of the group is blocked similarly:
```
│ Error: Client Error
│
│ Failed to delete object (DELETE), got error: HTTP Request failed: StatusCode 400, {"errors":["This adaptive policy group is in use by 8 ports on
│ netascode-network-01 - switch. Adaptive policy groups cannot be removed when in use."]}
```

This is due to meraki_switch_port doing nothing on deletion
(there is no DELETE endpoint).

Do a PUT on deletion, setting these properties:
- `"accessPolicyType": "Open"` - to remove `accessPolicyNumber`.
  Setting `accessPolicyNumber` itself to `null` fails with
  "'accessPolicyNumber' must be an integer".
  Setting the type to `"Open"` does remove the number as well, though.
- `"adaptivePolicyGroupId": null`.
  Always sending `"adaptivePolicyGroupId": null` on deletion
  can fail with "Adaptive Policy is not enabled in this network".
  That refers to meraki_organization_adaptive_policy_settings resource
  having adaptive policy enabled for this network.

  Add non-generated code to only send that
  if `adaptive_policy_group_id` was previously set
  (which would mean that adaptive policy
  would have been enabled on the network -
  we can't check that directly here).
- `"profile": {"enabled": false}`.
  Note: the profile behavior was not tested.
  The `profile_* ` attributes might not be
  blocking the profile's deletion at all
  (and therefore the change might be unnecessary),
  or setting `enabled` to `false` might not be enough
  to avoid `profile_id` possibly blocking the profile's deletion.

`port_schedule_id` does not block deletion of the port schedule -
deleting the port schedule clears the ID in the port;
so it was left unchanged (not cleared on port deletion).