### PR TITLE
switch_ports: Unset adaptive policy on port deletion

### DIFF
--- a/internal/provider/model_resource_meraki_switch_ports.go
+++ b/internal/provider/model_resource_meraki_switch_ports.go
@@ -744,16 +744,20 @@ func (data *ResourceSwitchPorts) fromBodyImport(ctx context.Context, res meraki.
 
 // End of section. //template:end fromBodyImport
 
-// Section below is generated&owned by "gen/generator.go". //template:begin toDestroyBody
-
-func (data ResourceSwitchPorts) toDestroyBody(ctx context.Context) string {
+func (data ResourceSwitchPortsItems) toDestroyBody(ctx context.Context) string {
 	body := ""
 	body, _ = sjson.Set(body, "accessPolicyType", "Open")
+	if !data.AdaptivePolicyGroupId.IsNull() {
+		// This can fail with "Adaptive Policy is not enabled in this network"
+		// if meraki_organization_adaptive_policy_settings resource
+		// does not have adaptive policy enabled for this network.
+		// Unset adaptive policy group ID only if it was already set
+		// (which could only be done if adaptive policy *is* enabled on the network first).
+		body, _ = sjson.Set(body, "adaptivePolicyGroupId", nil)
+	}
 	body, _ = sjson.Set(body, "profile.enabled", false)
 	return body
 }
-
-// End of section. //template:end toDestroyBody
 
 // Section below is generated&owned by "gen/generator.go". //template:begin hasChanges
 

--- a/internal/provider/resource_meraki_switch_ports.go
+++ b/internal/provider/resource_meraki_switch_ports.go
@@ -327,8 +327,6 @@ func (r *SwitchPortsResource) Read(ctx context.Context, req resource.ReadRequest
 
 // End of section. //template:end read
 
-// Section below is generated&owned by "gen/generator.go". //template:begin update
-
 func (r *SwitchPortsResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan, state ResourceSwitchPorts
 
@@ -363,7 +361,7 @@ func (r *SwitchPortsResource) Update(ctx context.Context, req resource.UpdateReq
 			actions = append(actions, meraki.ActionModel{
 				Operation: "update",
 				Resource:  plan.getItemPath(itemState.PortId.ValueString()),
-				Body:      plan.toDestroyBody(ctx),
+				Body:      itemState.toDestroyBody(ctx),
 			})
 		}
 	}
@@ -413,10 +411,6 @@ func (r *SwitchPortsResource) Update(ctx context.Context, req resource.UpdateReq
 	resp.Diagnostics.Append(diags...)
 }
 
-// End of section. //template:end update
-
-// Section below is generated&owned by "gen/generator.go". //template:begin delete
-
 func (r *SwitchPortsResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var state ResourceSwitchPorts
 
@@ -433,7 +427,7 @@ func (r *SwitchPortsResource) Delete(ctx context.Context, req resource.DeleteReq
 		actions[i] = meraki.ActionModel{
 			Operation: "update",
 			Resource:  state.getItemPath(item.PortId.ValueString()),
-			Body:      state.toDestroyBody(ctx),
+			Body:      item.toDestroyBody(ctx),
 		}
 	}
 	if len(actions) > 0 {
@@ -448,8 +442,6 @@ func (r *SwitchPortsResource) Delete(ctx context.Context, req resource.DeleteReq
 
 	resp.State.RemoveResource(ctx)
 }
-
-// End of section. //template:end delete
 
 // Section below is generated&owned by "gen/generator.go". //template:begin import
 func (r *SwitchPortsResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {


### PR DESCRIPTION
If `adaptive_policy_group_id` is set in a port,
deleting the adaptive policy group after the port from the list fails:
```
Error: Client Error
Failed to delete object (DELETE), got error: HTTP Request failed: StatusCode
400, {"errors":["This adaptive policy group is in use on the following ports
in the netascode-network-01 - switch network: switch
netascode-access-switch-01, port 7; switch netascode-access-switch-01, port
10; switch netascode-access-switch-01, port 11; switch
netascode-access-switch-01, port 12; switch netascode-access-switch-01, port
5. Please remove the policy from these ports before deleting the group."]}
```

This was already fixed in `switch_port` (the non-bulk resource) by setting `"adaptivePolicyGroupId": null`
in 633bcffab77e006ac328a78fd30f8dd2ba64516d
by overriding the generated code manually
instead of using `destroy_value` to generate it.
The manual change was not copied when the bulk resource was added.

The change had to be done manually due to API behavior: https://github.com/CiscoDevNet/terraform-provider-meraki/pull/89/commits/633bcffab77e006ac328a78fd30f8dd2ba64516d
> Always sending `"adaptivePolicyGroupId": null` on deletion
> can fail with "Adaptive Policy is not enabled in this network".
> That refers to meraki_organization_adaptive_policy_settings resource
> having adaptive policy enabled for this network.
>
> Only send that if `adaptive_policy_group_id` was previously set
> (which would mean that adaptive policy
> would have been enabled on the network -
> we can't check that directly here).