### PR TITLE
meraki_switch_ports clarification

### DIFF
--- a/docs/resources/switch_ports.md
+++ b/docs/resources/switch_ports.md
@@ -24,8 +24,6 @@ resource "meraki_switch_ports" "example" {
   organization_id = "123456"
   items = [{
     port_id                     = "1"
-    access_policy_type          = "Sticky MAC allow list"
-    allowed_vlans               = "1,3,5-10"
     dai_trusted                 = false
     enabled                     = true
     isolation_enabled           = false
@@ -39,6 +37,23 @@ resource "meraki_switch_ports" "example" {
     udld                        = "Alert only"
     vlan                        = 10
     voice_vlan                  = 20
+  },
+  {
+    port_id                     = "2"
+    access_policy_type          = "Sticky MAC allow list"
+    allowed_vlans               = "1,3,5-10"
+    dai_trusted                 = false
+    enabled                     = true
+    isolation_enabled           = false
+    link_negotiation            = "Auto negotiate"
+    name                        = "My switch port"
+    poe_enabled                 = false
+    rstp_enabled                = true
+    sticky_mac_allow_list_limit = 5
+    stp_guard                   = "disabled"
+    type                        = "trunk"
+    udld                        = "Alert only"
+    vlan                        = 10
     profile_enabled             = false
     sticky_mac_allow_list       = ["34:56:fe:ce:8e:b0"]
     tags                        = ["tag1"]


### PR DESCRIPTION
Updating the example to include two ports/items for better differentiation between `meraki_switch_port` and `meraki_switch_ports`.