### PR TITLE
expose computed id on SLA policy items

### DIFF
--- a/docs/data-sources/appliance_vpn_site_to_site_ipsec_peers_slas.md
+++ b/docs/data-sources/appliance_vpn_site_to_site_ipsec_peers_slas.md
@@ -35,5 +35,6 @@ data "meraki_appliance_vpn_site_to_site_ipsec_peers_slas" "example" {
 
 Read-Only:
 
+- `id` (String) SLA policy ID
 - `name` (String) SLA policy name
 - `uri` (String) Endpoint for testing SLA

--- a/docs/resources/appliance_vpn_site_to_site_ipsec_peers_slas.md
+++ b/docs/resources/appliance_vpn_site_to_site_ipsec_peers_slas.md
@@ -44,6 +44,10 @@ Required:
 - `name` (String) SLA policy name
 - `uri` (String) Endpoint for testing SLA
 
+Read-Only:
+
+- `id` (String) SLA policy ID
+
 ## Import
 
 Import is supported using the following syntax:

--- a/gen/definitions/appliance_vpn_site_to_site_ipsec_peers_slas.yaml
+++ b/gen/definitions/appliance_vpn_site_to_site_ipsec_peers_slas.yaml
@@ -19,6 +19,11 @@ attributes:
     description: List of IPsec SLA policies
     destroy_value: '[]interface{}{}'
     attributes:
+      - model_name: id
+        type: String
+        computed: true
+        description: SLA policy ID
+        example: "12345"
       - model_name: name
         type: String
         id: true

--- a/internal/provider/data_source_meraki_appliance_vpn_site_to_site_ipsec_peers_slas.go
+++ b/internal/provider/data_source_meraki_appliance_vpn_site_to_site_ipsec_peers_slas.go
@@ -70,6 +70,10 @@ func (d *ApplianceVPNSiteToSiteIPsecPeersSLAsDataSource) Schema(ctx context.Cont
 				Computed:            true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							MarkdownDescription: "SLA policy ID",
+							Computed:            true,
+						},
 						"name": schema.StringAttribute{
 							MarkdownDescription: "SLA policy name",
 							Computed:            true,

--- a/internal/provider/model_meraki_appliance_vpn_site_to_site_ipsec_peers_slas.go
+++ b/internal/provider/model_meraki_appliance_vpn_site_to_site_ipsec_peers_slas.go
@@ -42,6 +42,7 @@ type ApplianceVPNSiteToSiteIPsecPeersSLAs struct {
 }
 
 type ApplianceVPNSiteToSiteIPsecPeersSLAsItems struct {
+	Id   types.String `tfsdk:"id"`
 	Name types.String `tfsdk:"name"`
 	Uri  types.String `tfsdk:"uri"`
 }
@@ -86,6 +87,11 @@ func (data *ApplianceVPNSiteToSiteIPsecPeersSLAs) fromBody(ctx context.Context, 
 		value.ForEach(func(k, res gjson.Result) bool {
 			parent := &data
 			data := ApplianceVPNSiteToSiteIPsecPeersSLAsItems{}
+			if value := res.Get("id"); value.Exists() && value.Value() != nil {
+				data.Id = types.StringValue(value.String())
+			} else {
+				data.Id = types.StringNull()
+			}
 			if value := res.Get("name"); value.Exists() && value.Value() != nil {
 				data.Name = types.StringValue(value.String())
 			} else {
@@ -147,6 +153,11 @@ func (data *ApplianceVPNSiteToSiteIPsecPeersSLAs) fromBodyPartial(ctx context.Co
 
 			continue
 		}
+		if value := res.Get("id"); value.Exists() && !data.Id.IsNull() {
+			data.Id = types.StringValue(value.String())
+		} else {
+			data.Id = types.StringNull()
+		}
 		if value := res.Get("name"); value.Exists() && !data.Name.IsNull() {
 			data.Name = types.StringValue(value.String())
 		} else {
@@ -168,6 +179,51 @@ func (data *ApplianceVPNSiteToSiteIPsecPeersSLAs) fromBodyPartial(ctx context.Co
 // fromBodyUnknowns updates the Unknown Computed tfstate values from a JSON.
 // Known values are not changed (usual for Computed attributes with UseStateForUnknown or with Default).
 func (data *ApplianceVPNSiteToSiteIPsecPeersSLAs) fromBodyUnknowns(ctx context.Context, res meraki.Res) {
+	for i := 0; i < len(data.Items); i++ {
+		keys := [...]string{"name"}
+		keyValues := [...]string{data.Items[i].Name.ValueString()}
+
+		parent := &data
+		data := (*parent).Items[i]
+		parentRes := &res
+		var res gjson.Result
+
+		parentRes.Get("items").ForEach(
+			func(_, v gjson.Result) bool {
+				found := false
+				for ik := range keys {
+					if v.Get(keys[ik]).String() != keyValues[ik] {
+						found = false
+						break
+					}
+					found = true
+				}
+				if found {
+					res = v
+					return false
+				}
+				return true
+			},
+		)
+		if !res.Exists() {
+			tflog.Debug(ctx, fmt.Sprintf("removing Items[%d] = %+v",
+				i,
+				(*parent).Items[i],
+			))
+			(*parent).Items = slices.Delete((*parent).Items, i, i+1)
+			i--
+
+			continue
+		}
+		if data.Id.IsUnknown() {
+			if value := res.Get("id"); value.Exists() && !data.Id.IsNull() {
+				data.Id = types.StringValue(value.String())
+			} else {
+				data.Id = types.StringNull()
+			}
+		}
+		(*parent).Items[i] = data
+	}
 }
 
 // End of section. //template:end fromBodyUnknowns

--- a/internal/provider/resource_meraki_appliance_vpn_site_to_site_ipsec_peers_slas.go
+++ b/internal/provider/resource_meraki_appliance_vpn_site_to_site_ipsec_peers_slas.go
@@ -80,6 +80,13 @@ func (r *ApplianceVPNSiteToSiteIPsecPeersSLAsResource) Schema(ctx context.Contex
 				Required:            true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("SLA policy ID").String,
+							Computed:            true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
+						},
 						"name": schema.StringAttribute{
 							MarkdownDescription: helpers.NewAttributeDescription("SLA policy name").String,
 							Required:            true,


### PR DESCRIPTION
Add id (computed) attribute to appliance_vpn_site_to_site_ipsec_peers_slas items so downstream modules can build name-to-id lookup maps, similar to the organizations_network_ids pattern.

need it as the config require sla id when configuring and we want to use the name (similar to network id). 