### PR TITLE
Enhance firewall rules with policy object support 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add support for policy objects (`OBJ(<id>)`) and policy object groups (`GRP(<id>)`) in `src_cidr` and `dest_cidr` fields of `meraki_appliance_l3_firewall_rules` and `meraki_appliance_cellular_firewall_rules` resources.[link](https://github.com/CiscoDevNet/terraform-provider-meraki/issues/201)
+
 ## 1.10.0
 
 - Mark sensitive attributes (passwords, secrets, PSKs, passphrases, tokens, SNMP community strings) to prevent exposure in plan output and logs

--- a/docs/data-sources/appliance_cellular_firewall_rules.md
+++ b/docs/data-sources/appliance_cellular_firewall_rules.md
@@ -36,10 +36,10 @@ data "meraki_appliance_cellular_firewall_rules" "example" {
 Read-Only:
 
 - `comment` (String) Description of the rule (optional)
-- `dest_cidr` (String) Comma-separated list of destination IP address(es) (in IP or CIDR notation), fully-qualified domain names (FQDN) or `any`
+- `dest_cidr` (String) Comma-separated list of destination IP address(es) (in IP or CIDR notation), fully-qualified domain names (FQDN), `any`, policy objects using format `OBJ(<policy_object_id>)`, or policy object groups using format `GRP(<policy_object_group_id>)`
 - `dest_port` (String) Comma-separated list of destination port(s) (integer in the range 1-65535), or `any`
 - `policy` (String) `allow` or `deny` traffic specified by this rule
 - `protocol` (String) The type of protocol (must be `tcp`, `udp`, `icmp`, `icmp6` or `any`)
-- `src_cidr` (String) Comma-separated list of source IP address(es) (in IP or CIDR notation), or `any` (note: FQDN not supported for source addresses)
+- `src_cidr` (String) Comma-separated list of source IP address(es) (in IP or CIDR notation), `any` (note: FQDN not supported for source addresses), policy objects using format `OBJ(<policy_object_id>)`, or policy object groups using format `GRP(<policy_object_group_id>)`
 - `src_port` (String) Comma-separated list of source port(s) (integer in the range 1-65535), or `any`
 - `syslog_enabled` (Boolean) Log this rule to syslog (true or false, boolean value) - only applicable if a syslog has been configured (optional)

--- a/docs/data-sources/appliance_l3_firewall_rules.md
+++ b/docs/data-sources/appliance_l3_firewall_rules.md
@@ -37,10 +37,10 @@ data "meraki_appliance_l3_firewall_rules" "example" {
 Read-Only:
 
 - `comment` (String) Description of the rule (optional)
-- `dest_cidr` (String) Comma-separated list of destination IP address(es) (in IP or CIDR notation), fully-qualified domain names (FQDN) or `Any`
+- `dest_cidr` (String) Comma-separated list of destination IP address(es) (in IP or CIDR notation), fully-qualified domain names (FQDN), `Any`, policy objects using format `OBJ(<policy_object_id>)`, or policy object groups using format `GRP(<policy_object_group_id>)`
 - `dest_port` (String) Comma-separated list of destination port(s) (integer in the range 1-65535), or `Any`
 - `policy` (String) `allow` or `deny` traffic specified by this rule
 - `protocol` (String) The type of protocol (must be `tcp`, `udp`, `icmp`, `icmp6` or `any`)
-- `src_cidr` (String) Comma-separated list of source IP address(es) (in IP or CIDR notation), or `Any` (note: FQDN not supported for source addresses)
+- `src_cidr` (String) Comma-separated list of source IP address(es) (in IP or CIDR notation), `Any` (note: FQDN not supported for source addresses), policy objects using format `OBJ(<policy_object_id>)`, or policy object groups using format `GRP(<policy_object_group_id>)`
 - `src_port` (String) Comma-separated list of source port(s) (integer in the range 1-65535), or `Any`
 - `syslog_enabled` (Boolean) Log this rule to syslog (true or false, boolean value) - only applicable if a syslog has been configured (optional)

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -7,6 +7,10 @@ description: |-
 
 # Changelog
 
+## Unreleased
+
+- Add support for policy objects (`OBJ(<id>)`) and policy object groups (`GRP(<id>)`) in `src_cidr` and `dest_cidr` fields of `meraki_appliance_l3_firewall_rules` and `meraki_appliance_cellular_firewall_rules` resources.[link](https://github.com/CiscoDevNet/terraform-provider-meraki/issues/201)
+
 ## 1.10.0
 
 - Mark sensitive attributes (passwords, secrets, PSKs, passphrases, tokens, SNMP community strings) to prevent exposure in plan output and logs

--- a/docs/resources/appliance_cellular_firewall_rules.md
+++ b/docs/resources/appliance_cellular_firewall_rules.md
@@ -47,12 +47,12 @@ resource "meraki_appliance_cellular_firewall_rules" "example" {
 
 Required:
 
-- `dest_cidr` (String) Comma-separated list of destination IP address(es) (in IP or CIDR notation), fully-qualified domain names (FQDN) or `any`
+- `dest_cidr` (String) Comma-separated list of destination IP address(es) (in IP or CIDR notation), fully-qualified domain names (FQDN), `any`, policy objects using format `OBJ(<policy_object_id>)`, or policy object groups using format `GRP(<policy_object_group_id>)`
 - `policy` (String) `allow` or `deny` traffic specified by this rule
   - Choices: `allow`, `deny`
 - `protocol` (String) The type of protocol (must be `tcp`, `udp`, `icmp`, `icmp6` or `any`)
   - Choices: `any`, `icmp`, `icmp6`, `tcp`, `udp`
-- `src_cidr` (String) Comma-separated list of source IP address(es) (in IP or CIDR notation), or `any` (note: FQDN not supported for source addresses)
+- `src_cidr` (String) Comma-separated list of source IP address(es) (in IP or CIDR notation), `any` (note: FQDN not supported for source addresses), policy objects using format `OBJ(<policy_object_id>)`, or policy object groups using format `GRP(<policy_object_group_id>)`
 
 Optional:
 

--- a/docs/resources/appliance_l3_firewall_rules.md
+++ b/docs/resources/appliance_l3_firewall_rules.md
@@ -52,12 +52,12 @@ resource "meraki_appliance_l3_firewall_rules" "example" {
 
 Required:
 
-- `dest_cidr` (String) Comma-separated list of destination IP address(es) (in IP or CIDR notation), fully-qualified domain names (FQDN) or `Any`
+- `dest_cidr` (String) Comma-separated list of destination IP address(es) (in IP or CIDR notation), fully-qualified domain names (FQDN), `Any`, policy objects using format `OBJ(<policy_object_id>)`, or policy object groups using format `GRP(<policy_object_group_id>)`
 - `policy` (String) `allow` or `deny` traffic specified by this rule
   - Choices: `allow`, `deny`
 - `protocol` (String) The type of protocol (must be `tcp`, `udp`, `icmp`, `icmp6` or `any`)
   - Choices: `any`, `icmp`, `icmp6`, `tcp`, `udp`
-- `src_cidr` (String) Comma-separated list of source IP address(es) (in IP or CIDR notation), or `Any` (note: FQDN not supported for source addresses)
+- `src_cidr` (String) Comma-separated list of source IP address(es) (in IP or CIDR notation), `Any` (note: FQDN not supported for source addresses), policy objects using format `OBJ(<policy_object_id>)`, or policy object groups using format `GRP(<policy_object_group_id>)`
 
 Optional:
 

--- a/gen/definitions/appliance_cellular_firewall_rules.yaml
+++ b/gen/definitions/appliance_cellular_firewall_rules.yaml
@@ -28,7 +28,7 @@ attributes:
       - model_name: destCidr
         type: String
         mandatory: true
-        description: Comma-separated list of destination IP address(es) (in IP or CIDR notation), fully-qualified domain names (FQDN) or `any`
+        description: Comma-separated list of destination IP address(es) (in IP or CIDR notation), fully-qualified domain names (FQDN), `any`, policy objects using format `OBJ(<policy_object_id>)`, or policy object groups using format `GRP(<policy_object_group_id>)`
         example: 192.168.1.0/24
       - model_name: destPort
         type: String
@@ -50,7 +50,7 @@ attributes:
       - model_name: srcCidr
         type: String
         mandatory: true
-        description: 'Comma-separated list of source IP address(es) (in IP or CIDR notation), or `any` (note: FQDN not supported for source addresses)'
+        description: 'Comma-separated list of source IP address(es) (in IP or CIDR notation), `any` (note: FQDN not supported for source addresses), policy objects using format `OBJ(<policy_object_id>)`, or policy object groups using format `GRP(<policy_object_group_id>)`'
         example: Any
       - model_name: srcPort
         type: String
@@ -70,3 +70,31 @@ test_prerequisites: |
     name            = var.test_network
     product_types   = ["appliance"]
   }
+additional_tests:
+  - |-
+    resource "meraki_organization_policy_object" "test" {
+      organization_id = data.meraki_organization.test.id
+      name            = "test_policy_object"
+      category        = "network"
+      type            = "cidr"
+      cidr            = "10.10.10.1/32"
+    }
+    resource "meraki_organization_policy_object_group" "test" {
+      organization_id = data.meraki_organization.test.id
+      name            = "test_policy_group"
+      category        = "NetworkObjectGroup"
+      object_ids      = [meraki_organization_policy_object.test.id]
+    }
+    resource "meraki_appliance_cellular_firewall_rules" "test" {
+      network_id = meraki_network.test.id
+      rules = [{
+        comment        = "Policy object based rule"
+        dest_cidr      = "GRP(${meraki_organization_policy_object_group.test.id}),OBJ(${meraki_organization_policy_object.test.id})"
+        dest_port      = "443"
+        policy         = "allow"
+        protocol       = "tcp"
+        src_cidr       = "Any"
+        src_port       = "Any"
+        syslog_enabled = false
+      }]
+    }

--- a/gen/definitions/appliance_l3_firewall_rules.yaml
+++ b/gen/definitions/appliance_l3_firewall_rules.yaml
@@ -33,7 +33,7 @@ attributes:
       - model_name: destCidr
         type: String
         mandatory: true
-        description: Comma-separated list of destination IP address(es) (in IP or CIDR notation), fully-qualified domain names (FQDN) or `Any`
+        description: Comma-separated list of destination IP address(es) (in IP or CIDR notation), fully-qualified domain names (FQDN), `Any`, policy objects using format `OBJ(<policy_object_id>)`, or policy object groups using format `GRP(<policy_object_group_id>)`
         example: 192.168.1.0/24
       - model_name: destPort
         type: String
@@ -55,7 +55,7 @@ attributes:
       - model_name: srcCidr
         type: String
         mandatory: true
-        description: 'Comma-separated list of source IP address(es) (in IP or CIDR notation), or `Any` (note: FQDN not supported for source addresses)'
+        description: 'Comma-separated list of source IP address(es) (in IP or CIDR notation), `Any` (note: FQDN not supported for source addresses), policy objects using format `OBJ(<policy_object_id>)`, or policy object groups using format `GRP(<policy_object_group_id>)`'
         example: Any
       - model_name: srcPort
         type: String
@@ -83,5 +83,32 @@ additional_tests:
         policy = "allow"
         protocol = "any"
         src_cidr = "Any"
+      }]
+    }
+  - |-
+    resource "meraki_organization_policy_object" "test" {
+      organization_id = data.meraki_organization.test.id
+      name            = "test_policy_object"
+      category        = "network"
+      type            = "cidr"
+      cidr            = "10.10.10.1/32"
+    }
+    resource "meraki_organization_policy_object_group" "test" {
+      organization_id = data.meraki_organization.test.id
+      name            = "test_policy_group"
+      category        = "NetworkObjectGroup"
+      object_ids      = [meraki_organization_policy_object.test.id]
+    }
+    resource "meraki_appliance_l3_firewall_rules" "test" {
+      network_id = meraki_network.test.id
+      rules = [{
+        comment        = "Policy object based rule"
+        dest_cidr      = "GRP(${meraki_organization_policy_object_group.test.id}),OBJ(${meraki_organization_policy_object.test.id})"
+        dest_port      = "443"
+        policy         = "allow"
+        protocol       = "tcp"
+        src_cidr       = "Any"
+        src_port       = "Any"
+        syslog_enabled = false
       }]
     }

--- a/internal/provider/data_source_meraki_appliance_cellular_firewall_rules.go
+++ b/internal/provider/data_source_meraki_appliance_cellular_firewall_rules.go
@@ -75,7 +75,7 @@ func (d *ApplianceCellularFirewallRulesDataSource) Schema(ctx context.Context, r
 							Computed:            true,
 						},
 						"dest_cidr": schema.StringAttribute{
-							MarkdownDescription: "Comma-separated list of destination IP address(es) (in IP or CIDR notation), fully-qualified domain names (FQDN) or `any`",
+							MarkdownDescription: "Comma-separated list of destination IP address(es) (in IP or CIDR notation), fully-qualified domain names (FQDN), `any`, policy objects using format `OBJ(<policy_object_id>)`, or policy object groups using format `GRP(<policy_object_group_id>)`",
 							Computed:            true,
 						},
 						"dest_port": schema.StringAttribute{
@@ -91,7 +91,7 @@ func (d *ApplianceCellularFirewallRulesDataSource) Schema(ctx context.Context, r
 							Computed:            true,
 						},
 						"src_cidr": schema.StringAttribute{
-							MarkdownDescription: "Comma-separated list of source IP address(es) (in IP or CIDR notation), or `any` (note: FQDN not supported for source addresses)",
+							MarkdownDescription: "Comma-separated list of source IP address(es) (in IP or CIDR notation), `any` (note: FQDN not supported for source addresses), policy objects using format `OBJ(<policy_object_id>)`, or policy object groups using format `GRP(<policy_object_group_id>)`",
 							Computed:            true,
 						},
 						"src_port": schema.StringAttribute{

--- a/internal/provider/data_source_meraki_appliance_l3_firewall_rules.go
+++ b/internal/provider/data_source_meraki_appliance_l3_firewall_rules.go
@@ -79,7 +79,7 @@ func (d *ApplianceL3FirewallRulesDataSource) Schema(ctx context.Context, req dat
 							Computed:            true,
 						},
 						"dest_cidr": schema.StringAttribute{
-							MarkdownDescription: "Comma-separated list of destination IP address(es) (in IP or CIDR notation), fully-qualified domain names (FQDN) or `Any`",
+							MarkdownDescription: "Comma-separated list of destination IP address(es) (in IP or CIDR notation), fully-qualified domain names (FQDN), `Any`, policy objects using format `OBJ(<policy_object_id>)`, or policy object groups using format `GRP(<policy_object_group_id>)`",
 							Computed:            true,
 						},
 						"dest_port": schema.StringAttribute{
@@ -95,7 +95,7 @@ func (d *ApplianceL3FirewallRulesDataSource) Schema(ctx context.Context, req dat
 							Computed:            true,
 						},
 						"src_cidr": schema.StringAttribute{
-							MarkdownDescription: "Comma-separated list of source IP address(es) (in IP or CIDR notation), or `Any` (note: FQDN not supported for source addresses)",
+							MarkdownDescription: "Comma-separated list of source IP address(es) (in IP or CIDR notation), `Any` (note: FQDN not supported for source addresses), policy objects using format `OBJ(<policy_object_id>)`, or policy object groups using format `GRP(<policy_object_group_id>)`",
 							Computed:            true,
 						},
 						"src_port": schema.StringAttribute{

--- a/internal/provider/resource_meraki_appliance_cellular_firewall_rules.go
+++ b/internal/provider/resource_meraki_appliance_cellular_firewall_rules.go
@@ -87,7 +87,7 @@ func (r *ApplianceCellularFirewallRulesResource) Schema(ctx context.Context, req
 							Optional:            true,
 						},
 						"dest_cidr": schema.StringAttribute{
-							MarkdownDescription: helpers.NewAttributeDescription("Comma-separated list of destination IP address(es) (in IP or CIDR notation), fully-qualified domain names (FQDN) or `any`").String,
+							MarkdownDescription: helpers.NewAttributeDescription("Comma-separated list of destination IP address(es) (in IP or CIDR notation), fully-qualified domain names (FQDN), `any`, policy objects using format `OBJ(<policy_object_id>)`, or policy object groups using format `GRP(<policy_object_group_id>)`").String,
 							Required:            true,
 						},
 						"dest_port": schema.StringAttribute{
@@ -109,7 +109,7 @@ func (r *ApplianceCellularFirewallRulesResource) Schema(ctx context.Context, req
 							},
 						},
 						"src_cidr": schema.StringAttribute{
-							MarkdownDescription: helpers.NewAttributeDescription("Comma-separated list of source IP address(es) (in IP or CIDR notation), or `any` (note: FQDN not supported for source addresses)").String,
+							MarkdownDescription: helpers.NewAttributeDescription("Comma-separated list of source IP address(es) (in IP or CIDR notation), `any` (note: FQDN not supported for source addresses), policy objects using format `OBJ(<policy_object_id>)`, or policy object groups using format `GRP(<policy_object_group_id>)`").String,
 							Required:            true,
 						},
 						"src_port": schema.StringAttribute{

--- a/internal/provider/resource_meraki_appliance_cellular_firewall_rules_test.go
+++ b/internal/provider/resource_meraki_appliance_cellular_firewall_rules_test.go
@@ -63,6 +63,9 @@ func TestAccMerakiApplianceCellularFirewallRules(t *testing.T) {
 		ImportStateVerifyIgnore: []string{},
 		Check:                   resource.ComposeTestCheckFunc(checks...),
 	})
+	steps = append(steps, resource.TestStep{
+		Config: testAccMerakiApplianceCellularFirewallRulesPrerequisitesConfig + testAccApplianceCellularFirewallRulesConfigAdditional0,
+	})
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -145,5 +148,34 @@ func testAccMerakiApplianceCellularFirewallRulesConfig_all() string {
 // End of section. //template:end testAccConfigAll
 
 // Section below is generated&owned by "gen/generator.go". //template:begin testAccConfigAdditional
+
+const testAccApplianceCellularFirewallRulesConfigAdditional0 = `
+resource "meraki_organization_policy_object" "test" {
+  organization_id = data.meraki_organization.test.id
+  name            = "test_policy_object"
+  category        = "network"
+  type            = "cidr"
+  cidr            = "10.10.10.1/32"
+}
+resource "meraki_organization_policy_object_group" "test" {
+  organization_id = data.meraki_organization.test.id
+  name            = "test_policy_group"
+  category        = "NetworkObjectGroup"
+  object_ids      = [meraki_organization_policy_object.test.id]
+}
+resource "meraki_appliance_cellular_firewall_rules" "test" {
+  network_id = meraki_network.test.id
+  rules = [{
+    comment        = "Policy object based rule"
+    dest_cidr      = "GRP(${meraki_organization_policy_object_group.test.id}),OBJ(${meraki_organization_policy_object.test.id})"
+    dest_port      = "443"
+    policy         = "allow"
+    protocol       = "tcp"
+    src_cidr       = "Any"
+    src_port       = "Any"
+    syslog_enabled = false
+  }]
+}
+`
 
 // End of section. //template:end testAccConfigAdditional

--- a/internal/provider/resource_meraki_appliance_l3_firewall_rules.go
+++ b/internal/provider/resource_meraki_appliance_l3_firewall_rules.go
@@ -91,7 +91,7 @@ func (r *ApplianceL3FirewallRulesResource) Schema(ctx context.Context, req resou
 							Optional:            true,
 						},
 						"dest_cidr": schema.StringAttribute{
-							MarkdownDescription: helpers.NewAttributeDescription("Comma-separated list of destination IP address(es) (in IP or CIDR notation), fully-qualified domain names (FQDN) or `Any`").String,
+							MarkdownDescription: helpers.NewAttributeDescription("Comma-separated list of destination IP address(es) (in IP or CIDR notation), fully-qualified domain names (FQDN), `Any`, policy objects using format `OBJ(<policy_object_id>)`, or policy object groups using format `GRP(<policy_object_group_id>)`").String,
 							Required:            true,
 						},
 						"dest_port": schema.StringAttribute{
@@ -113,7 +113,7 @@ func (r *ApplianceL3FirewallRulesResource) Schema(ctx context.Context, req resou
 							},
 						},
 						"src_cidr": schema.StringAttribute{
-							MarkdownDescription: helpers.NewAttributeDescription("Comma-separated list of source IP address(es) (in IP or CIDR notation), or `Any` (note: FQDN not supported for source addresses)").String,
+							MarkdownDescription: helpers.NewAttributeDescription("Comma-separated list of source IP address(es) (in IP or CIDR notation), `Any` (note: FQDN not supported for source addresses), policy objects using format `OBJ(<policy_object_id>)`, or policy object groups using format `GRP(<policy_object_group_id>)`").String,
 							Required:            true,
 						},
 						"src_port": schema.StringAttribute{

--- a/internal/provider/resource_meraki_appliance_l3_firewall_rules_test.go
+++ b/internal/provider/resource_meraki_appliance_l3_firewall_rules_test.go
@@ -66,6 +66,9 @@ func TestAccMerakiApplianceL3FirewallRules(t *testing.T) {
 	steps = append(steps, resource.TestStep{
 		Config: testAccMerakiApplianceL3FirewallRulesPrerequisitesConfig + testAccApplianceL3FirewallRulesConfigAdditional0,
 	})
+	steps = append(steps, resource.TestStep{
+		Config: testAccMerakiApplianceL3FirewallRulesPrerequisitesConfig + testAccApplianceL3FirewallRulesConfigAdditional1,
+	})
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -156,6 +159,35 @@ resource "meraki_appliance_l3_firewall_rules" "test" {
     policy = "allow"
     protocol = "any"
     src_cidr = "Any"
+  }]
+}
+`
+
+const testAccApplianceL3FirewallRulesConfigAdditional1 = `
+resource "meraki_organization_policy_object" "test" {
+  organization_id = data.meraki_organization.test.id
+  name            = "test_policy_object"
+  category        = "network"
+  type            = "cidr"
+  cidr            = "10.10.10.1/32"
+}
+resource "meraki_organization_policy_object_group" "test" {
+  organization_id = data.meraki_organization.test.id
+  name            = "test_policy_group"
+  category        = "NetworkObjectGroup"
+  object_ids      = [meraki_organization_policy_object.test.id]
+}
+resource "meraki_appliance_l3_firewall_rules" "test" {
+  network_id = meraki_network.test.id
+  rules = [{
+    comment        = "Policy object based rule"
+    dest_cidr      = "GRP(${meraki_organization_policy_object_group.test.id}),OBJ(${meraki_organization_policy_object.test.id})"
+    dest_port      = "443"
+    policy         = "allow"
+    protocol       = "tcp"
+    src_cidr       = "Any"
+    src_port       = "Any"
+    syslog_enabled = false
   }]
 }
 `

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -7,6 +7,10 @@ description: |-
 
 # Changelog
 
+## Unreleased
+
+- Add support for policy objects (`OBJ(<id>)`) and policy object groups (`GRP(<id>)`) in `src_cidr` and `dest_cidr` fields of `meraki_appliance_l3_firewall_rules` and `meraki_appliance_cellular_firewall_rules` resources.[link](https://github.com/CiscoDevNet/terraform-provider-meraki/issues/201)
+
 ## 1.10.0
 
 - Mark sensitive attributes (passwords, secrets, PSKs, passphrases, tokens, SNMP community strings) to prevent exposure in plan output and logs


### PR DESCRIPTION
- Added support for policy objects (`OBJ(<id>)`) and policy object groups (`GRP(<id>)`) in the `src_cidr` and `dest_cidr` fields of `meraki_appliance_l3_firewall_rules` and `meraki_appliance_cellular_firewall_rules` resources.
- Updated documentation and schema descriptions to reflect these changes.