### PR TITLE
network_vlan_profile_assignment: Fix switch stack unassignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fix issue with `stack_ids` attribute of `meraki_network_vlan_profile_assignment` resource, [link](https://github.com/CiscoDevNet/terraform-provider-meraki/issues/224)
+
 ## 1.12.1
 
 - Fix "Missing Resource Identity After Update" provider error when updating resources with Terraform versions not supporting resource identity (< 1.12)

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -7,6 +7,10 @@ description: |-
 
 # Changelog
 
+## Unreleased
+
+- Fix issue with `stack_ids` attribute of `meraki_network_vlan_profile_assignment` resource, [link](https://github.com/CiscoDevNet/terraform-provider-meraki/issues/224)
+
 ## 1.12.1
 
 - Fix "Missing Resource Identity After Update" provider error when updating resources with Terraform versions not supporting resource identity (< 1.12)

--- a/gen/definitions/network_vlan_profile_assignment.yaml
+++ b/gen/definitions/network_vlan_profile_assignment.yaml
@@ -92,3 +92,15 @@ test_prerequisites: |
       }
     ]
   }
+additional_tests:
+  - |-
+    resource "meraki_switch_stack" "test" {
+      network_id = meraki_network.test.id
+      name       = "A cool stack"
+      serials    = meraki_network_device_claim.test.serials
+    }
+    resource "meraki_network_vlan_profile_assignment" "test" {
+      network_id         = meraki_network.test.id
+      vlan_profile_iname = meraki_network_vlan_profile.test.iname
+      stack_ids          = [meraki_switch_stack.test.id]
+    }

--- a/internal/provider/model_meraki_network_vlan_profile_assignment.go
+++ b/internal/provider/model_meraki_network_vlan_profile_assignment.go
@@ -184,12 +184,22 @@ func (data *NetworkVLANProfileAssignment) fromByDeviceBody(ctx context.Context, 
 		if profileIname != iname {
 			continue
 		}
+		if stackId := item.Get("stack.id").String(); stackId != "" {
+			if !stackIdSet[stackId] {
+				stackIdSet[stackId] = true
+				stackIdValues = append(stackIdValues, types.StringValue(stackId))
+			}
+			// When a stack is assigned to the profile,
+			// the byDevice response includes an assignment for every device in the stack,
+			// with the stack ID specified for each assignment.
+			// An assignment to an individual device (non-stack switch) is returned with null stack ID.
+			//
+			// Ignore the device serial if non-null stack ID is returned,
+			// so that we don't try to unassign the stack's devices on Update/Delete.
+			continue
+		}
 		if serial := item.Get("serial").String(); serial != "" {
 			serialValues = append(serialValues, types.StringValue(serial))
-		}
-		if stackId := item.Get("stack.id").String(); stackId != "" && !stackIdSet[stackId] {
-			stackIdSet[stackId] = true
-			stackIdValues = append(stackIdValues, types.StringValue(stackId))
 		}
 	}
 	if len(serialValues) > 0 {

--- a/internal/provider/resource_meraki_network_vlan_profile_assignment_test.go
+++ b/internal/provider/resource_meraki_network_vlan_profile_assignment_test.go
@@ -58,6 +58,9 @@ func TestAccMerakiNetworkVLANProfileAssignment(t *testing.T) {
 		ImportStateVerifyIgnore: []string{},
 		Check:                   resource.ComposeTestCheckFunc(checks...),
 	})
+	steps = append(steps, resource.TestStep{
+		Config: testAccMerakiNetworkVLANProfileAssignmentPrerequisitesConfig + testAccNetworkVLANProfileAssignmentConfigAdditional0,
+	})
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -167,5 +170,18 @@ func testAccMerakiNetworkVLANProfileAssignmentConfig_all() string {
 // End of section. //template:end testAccConfigAll
 
 // Section below is generated&owned by "gen/generator.go". //template:begin testAccConfigAdditional
+
+const testAccNetworkVLANProfileAssignmentConfigAdditional0 = `
+resource "meraki_switch_stack" "test" {
+  network_id = meraki_network.test.id
+  name       = "A cool stack"
+  serials    = meraki_network_device_claim.test.serials
+}
+resource "meraki_network_vlan_profile_assignment" "test" {
+  network_id         = meraki_network.test.id
+  vlan_profile_iname = meraki_network_vlan_profile.test.iname
+  stack_ids          = [meraki_switch_stack.test.id]
+}
+`
 
 // End of section. //template:end testAccConfigAdditional

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -7,6 +7,10 @@ description: |-
 
 # Changelog
 
+## Unreleased
+
+- Fix issue with `stack_ids` attribute of `meraki_network_vlan_profile_assignment` resource, [link](https://github.com/CiscoDevNet/terraform-provider-meraki/issues/224)
+
 ## 1.12.1
 
 - Fix "Missing Resource Identity After Update" provider error when updating resources with Terraform versions not supporting resource identity (< 1.12)


### PR DESCRIPTION
When a stack is assigned to the profile,
the byDevice response also includes an assignment
for every device in the stack.

The current logic treats this
as having both the stack and the individual switches assigned to the profile.

When the user only specifies the stack (but not the individual switches), this leads to an idempotency failure.

When the user specifies the individual switches as well, deletion fails, as the provider
tries to unassign each device individually,
which the API does not accept.

The byDevice GET response has enough information to work around this: When a stack is assigned to the profile,
it includes an assignment for every device in the stack, with the stack ID specified for each assignment.
An assignment to an individual (non-stack switch)
is returned with null stack ID.

Ignore the device serial if stack ID is returned in an assignment, so that we treat it as only an assignment of the stack and not the individual device
and don't try to unassign the individual devices on Update/Delete.

Fixes https://github.com/CiscoDevNet/terraform-provider-meraki/issues/224