### PR TITLE
network_vlan_profile_assignment: Fix switch stack test

### DIFF
--- a/gen/definitions/network_vlan_profile_assignment.yaml
+++ b/gen/definitions/network_vlan_profile_assignment.yaml
@@ -12,7 +12,7 @@ no_import: false
 no_read: false
 res_description: This resource manages the assignment of a VLAN profile to specific devices and switch stacks within a network.
 doc_category: Networks
-test_variables: [test_org, test_network, test_switch_1_serial]
+test_variables: [test_org, test_network, test_switch_1_serial, test_switch_2_serial]
 attributes:
   - tf_name: network_id
     type: String
@@ -56,7 +56,7 @@ test_prerequisites: |
   }
   resource "meraki_network_device_claim" "test" {
     network_id = meraki_network.test.id
-    serials    = [var.test_switch_1_serial]
+    serials    = [var.test_switch_1_serial, var.test_switch_2_serial]
   }
   resource "meraki_network_vlan_profile" "default" {
     network_id = meraki_network.test.id

--- a/internal/provider/data_source_meraki_network_vlan_profile_assignment_test.go
+++ b/internal/provider/data_source_meraki_network_vlan_profile_assignment_test.go
@@ -30,8 +30,8 @@ import (
 // Section below is generated&owned by "gen/generator.go". //template:begin testAccDataSource
 
 func TestAccDataSourceMerakiNetworkVLANProfileAssignment(t *testing.T) {
-	if os.Getenv("TF_VAR_test_org") == "" || os.Getenv("TF_VAR_test_network") == "" || os.Getenv("TF_VAR_test_switch_1_serial") == "" {
-		t.Skip("skipping test, set environment variable TF_VAR_test_org and TF_VAR_test_network and TF_VAR_test_switch_1_serial")
+	if os.Getenv("TF_VAR_test_org") == "" || os.Getenv("TF_VAR_test_network") == "" || os.Getenv("TF_VAR_test_switch_1_serial") == "" || os.Getenv("TF_VAR_test_switch_2_serial") == "" {
+		t.Skip("skipping test, set environment variable TF_VAR_test_org and TF_VAR_test_network and TF_VAR_test_switch_1_serial and TF_VAR_test_switch_2_serial")
 	}
 	var checks []resource.TestCheckFunc
 	resource.Test(t, resource.TestCase{
@@ -54,6 +54,7 @@ const testAccDataSourceMerakiNetworkVLANProfileAssignmentPrerequisitesConfig = `
 variable "test_org" {}
 variable "test_network" {}
 variable "test_switch_1_serial" {}
+variable "test_switch_2_serial" {}
 data "meraki_organization" "test" {
   name = var.test_org
 }
@@ -64,7 +65,7 @@ resource "meraki_network" "test" {
 }
 resource "meraki_network_device_claim" "test" {
   network_id = meraki_network.test.id
-  serials    = [var.test_switch_1_serial]
+  serials    = [var.test_switch_1_serial, var.test_switch_2_serial]
 }
 resource "meraki_network_vlan_profile" "default" {
   network_id = meraki_network.test.id

--- a/internal/provider/resource_meraki_network_vlan_profile_assignment_test.go
+++ b/internal/provider/resource_meraki_network_vlan_profile_assignment_test.go
@@ -34,8 +34,8 @@ import (
 // Section below is generated&owned by "gen/generator.go". //template:begin testAcc
 
 func TestAccMerakiNetworkVLANProfileAssignment(t *testing.T) {
-	if os.Getenv("TF_VAR_test_org") == "" || os.Getenv("TF_VAR_test_network") == "" || os.Getenv("TF_VAR_test_switch_1_serial") == "" {
-		t.Skip("skipping test, set environment variable TF_VAR_test_org and TF_VAR_test_network and TF_VAR_test_switch_1_serial")
+	if os.Getenv("TF_VAR_test_org") == "" || os.Getenv("TF_VAR_test_network") == "" || os.Getenv("TF_VAR_test_switch_1_serial") == "" || os.Getenv("TF_VAR_test_switch_2_serial") == "" {
+		t.Skip("skipping test, set environment variable TF_VAR_test_org and TF_VAR_test_network and TF_VAR_test_switch_1_serial and TF_VAR_test_switch_2_serial")
 	}
 	var checks []resource.TestCheckFunc
 
@@ -94,6 +94,7 @@ const testAccMerakiNetworkVLANProfileAssignmentPrerequisitesConfig = `
 variable "test_org" {}
 variable "test_network" {}
 variable "test_switch_1_serial" {}
+variable "test_switch_2_serial" {}
 data "meraki_organization" "test" {
   name = var.test_org
 }
@@ -104,7 +105,7 @@ resource "meraki_network" "test" {
 }
 resource "meraki_network_device_claim" "test" {
   network_id = meraki_network.test.id
-  serials    = [var.test_switch_1_serial]
+  serials    = [var.test_switch_1_serial, var.test_switch_2_serial]
 }
 resource "meraki_network_vlan_profile" "default" {
   network_id = meraki_network.test.id


### PR DESCRIPTION
A follow-up to https://github.com/CiscoDevNet/terraform-provider-meraki/pull/228:

The switch stack resource in the test was copied from `switch_stack.yaml`, where the switch stack used the claimed serials. That test had 2 serials (2 switches),
but `network_vlan_profile_assignment` test has only 1.

This was not caught because:
- I did not run the test locally (did not teardown my regular testing setup to use for provider testing instead).
- The Github Action failed for a different reason (`MERAKI_API_KEY` environment variable not being defined) and did not run tests as a result.
- The PR was merged without fixing the CI and rebasing.