### PR TITLE
#230 appliance_traffic_shaping_uplink_selection: Fix state refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Fix issue with `stack_ids` attribute of `meraki_network_vlan_profile_assignment` resource, [link](https://github.com/CiscoDevNet/terraform-provider-meraki/issues/224)
+- Fix idempotency issue with `vpn_traffic_uplink_preferences[].traffic_filters`, `wan_traffic_uplink_preferences[].traffic_filters` attributes of `meraki_appliance_traffic_shaping_uplink_selection` resource, [link](https://github.com/CiscoDevNet/terraform-provider-meraki/pull/235)
 
 ## 1.12.1
 

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -10,6 +10,7 @@ description: |-
 ## Unreleased
 
 - Fix issue with `stack_ids` attribute of `meraki_network_vlan_profile_assignment` resource, [link](https://github.com/CiscoDevNet/terraform-provider-meraki/issues/224)
+- Fix idempotency issue with `vpn_traffic_uplink_preferences[].traffic_filters`, `wan_traffic_uplink_preferences[].traffic_filters` attributes of `meraki_appliance_traffic_shaping_uplink_selection` resource, [link](https://github.com/CiscoDevNet/terraform-provider-meraki/pull/235)
 
 ## 1.12.1
 

--- a/gen/definitions/appliance_sdwan_internet_policies.yaml
+++ b/gen/definitions/appliance_sdwan_internet_policies.yaml
@@ -58,10 +58,10 @@ attributes:
         type: List
         mandatory: true
         description: Traffic filters
+        ordered_list: true
         attributes:
           - model_name: type
             type: String
-            id: true
             mandatory: true
             description: Traffic filter type. Must be `custom`, `major_application`, `application (NBAR)`, if type is `application`, you can pass either an NBAR App Category or Application
             example: custom

--- a/gen/definitions/appliance_traffic_shaping_uplink_selection.yaml
+++ b/gen/definitions/appliance_traffic_shaping_uplink_selection.yaml
@@ -77,7 +77,6 @@ attributes:
         attributes:
           - model_name: type
             type: String
-            id: true
             mandatory: true
             description: 'Type of this traffic filter. Must be one of: `applicationCategory`, `application` or `custom`'
             example: applicationCategory
@@ -184,7 +183,6 @@ attributes:
         attributes:
           - model_name: type
             type: String
-            id: true
             mandatory: true
             description: 'Type of this traffic filter. Must be one of: `custom`'
             example: custom

--- a/gen/definitions/appliance_traffic_shaping_uplink_selection.yaml
+++ b/gen/definitions/appliance_traffic_shaping_uplink_selection.yaml
@@ -74,6 +74,7 @@ attributes:
         type: List
         mandatory: true
         description: Array of traffic filters for this uplink preference rule
+        ordered_list: true
         attributes:
           - model_name: type
             type: String
@@ -180,6 +181,7 @@ attributes:
         type: List
         mandatory: true
         description: Array of traffic filters for this uplink preference rule
+        ordered_list: true
         attributes:
           - model_name: type
             type: String

--- a/gen/templates/bulk/model_data_source.go
+++ b/gen/templates/bulk/model_data_source.go
@@ -206,19 +206,8 @@ func (data *DataSource{{camelCase .BulkName}}) fromBody(ctx context.Context, res
 
 {{- range .Attributes}}
 	{{- range .Attributes}}
-		{{- if .OrderedList }}
-			{{- errorf "ordered_list not yet implemented at this depth"}}
-		{{- end}}
-
 		{{- range .Attributes}}
-			{{- if .OrderedList }}
-				{{- errorf "ordered_list not yet implemented at this depth"}}
-			{{- end}}
-
 			{{- range .Attributes}}
-				{{- if .OrderedList }}
-					{{- errorf "ordered_list not yet implemented at this depth"}}
-				{{- end}}
 				{{- range .Attributes}}
 					{{- errorf "attributes not yet implemented at this depth"}}
 				{{- end}}

--- a/gen/templates/bulk/model_resource.go
+++ b/gen/templates/bulk/model_resource.go
@@ -836,19 +836,8 @@ func (data *Resource{{camelCase .BulkName}}) hasChanges(ctx context.Context, sta
 
 {{- range .Attributes}}
 	{{- range .Attributes}}
-		{{- if .OrderedList }}
-			{{- errorf "ordered_list not yet implemented at this depth"}}
-		{{- end}}
-
 		{{- range .Attributes}}
-			{{- if .OrderedList }}
-				{{- errorf "ordered_list not yet implemented at this depth"}}
-			{{- end}}
-
 			{{- range .Attributes}}
-				{{- if .OrderedList }}
-					{{- errorf "ordered_list not yet implemented at this depth"}}
-				{{- end}}
 				{{- range .Attributes}}
 					{{- errorf "attributes not yet implemented at this depth"}}
 				{{- end}}

--- a/gen/templates/model.go
+++ b/gen/templates/model.go
@@ -607,19 +607,8 @@ func (data {{camelCase .Name}}) toDestroyBody(ctx context.Context) string {
 
 {{- range .Attributes}}
 	{{- range .Attributes}}
-		{{- if .OrderedList }}
-			{{- errorf "ordered_list not yet implemented at this depth"}}
-		{{- end}}
-
 		{{- range .Attributes}}
-			{{- if .OrderedList }}
-				{{- errorf "ordered_list not yet implemented at this depth"}}
-			{{- end}}
-
 			{{- range .Attributes}}
-				{{- if .OrderedList }}
-					{{- errorf "ordered_list not yet implemented at this depth"}}
-				{{- end}}
 				{{- range .Attributes}}
 					{{- errorf "attributes not yet implemented at this depth"}}
 				{{- end}}

--- a/internal/provider/model_meraki_appliance_sdwan_internet_policies.go
+++ b/internal/provider/model_meraki_appliance_sdwan_internet_policies.go
@@ -318,42 +318,18 @@ func (data *ApplianceSDWANInternetPolicies) fromBodyPartial(ctx context.Context,
 		} else {
 			data.PerformanceClassType = types.StringNull()
 		}
-		for i := 0; i < len(data.TrafficFilters); i++ {
-			keys := [...]string{"type"}
-			keyValues := [...]string{data.TrafficFilters[i].Type.ValueString()}
-
+		{
+			l := len(res.Get("trafficFilters").Array())
+			tflog.Debug(ctx, fmt.Sprintf("trafficFilters array resizing from %d to %d", len(data.TrafficFilters), l))
+			if len(data.TrafficFilters) > l {
+				data.TrafficFilters = data.TrafficFilters[:l]
+			}
+		}
+		for i := range data.TrafficFilters {
 			parent := &data
 			data := (*parent).TrafficFilters[i]
 			parentRes := &res
-			var res gjson.Result
-
-			parentRes.Get("trafficFilters").ForEach(
-				func(_, v gjson.Result) bool {
-					found := false
-					for ik := range keys {
-						if v.Get(keys[ik]).String() != keyValues[ik] {
-							found = false
-							break
-						}
-						found = true
-					}
-					if found {
-						res = v
-						return false
-					}
-					return true
-				},
-			)
-			if !res.Exists() {
-				tflog.Debug(ctx, fmt.Sprintf("removing TrafficFilters[%d] = %+v",
-					i,
-					(*parent).TrafficFilters[i],
-				))
-				(*parent).TrafficFilters = slices.Delete((*parent).TrafficFilters, i, i+1)
-				i--
-
-				continue
-			}
+			res := parentRes.Get(fmt.Sprintf("trafficFilters.%d", i))
 			if value := res.Get("type"); value.Exists() && !data.Type.IsNull() {
 				data.Type = types.StringValue(value.String())
 			} else {

--- a/internal/provider/model_meraki_appliance_traffic_shaping_uplink_selection.go
+++ b/internal/provider/model_meraki_appliance_traffic_shaping_uplink_selection.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net/url"
 	"slices"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -503,8 +504,8 @@ func (data *ApplianceTrafficShapingUplinkSelection) fromBodyPartial(ctx context.
 			data.PerformanceClassType = types.StringNull()
 		}
 		for i := 0; i < len(data.TrafficFilters); i++ {
-			keys := [...]string{"type"}
-			keyValues := [...]string{data.TrafficFilters[i].Type.ValueString()}
+			keys := [...]string{"type", "value.id", "value.protocol", "value.destination.cidr", "value.destination.fqdn", "value.destination.host", "value.destination.network", "value.destination.port", "value.destination.vlan", "value.source.cidr", "value.source.host", "value.source.network", "value.source.port", "value.source.vlan"}
+			keyValues := [...]string{data.TrafficFilters[i].Type.ValueString(), data.TrafficFilters[i].Id.ValueString(), data.TrafficFilters[i].Protocol.ValueString(), data.TrafficFilters[i].DestinationCidr.ValueString(), data.TrafficFilters[i].DestinationFqdn.ValueString(), strconv.FormatInt(data.TrafficFilters[i].DestinationHost.ValueInt64(), 10), data.TrafficFilters[i].DestinationNetwork.ValueString(), data.TrafficFilters[i].DestinationPort.ValueString(), strconv.FormatInt(data.TrafficFilters[i].DestinationVlan.ValueInt64(), 10), data.TrafficFilters[i].SourceCidr.ValueString(), strconv.FormatInt(data.TrafficFilters[i].SourceHost.ValueInt64(), 10), data.TrafficFilters[i].SourceNetwork.ValueString(), data.TrafficFilters[i].SourcePort.ValueString(), strconv.FormatInt(data.TrafficFilters[i].SourceVlan.ValueInt64(), 10)}
 
 			parent := &data
 			data := (*parent).TrafficFilters[i]

--- a/internal/provider/model_meraki_appliance_traffic_shaping_uplink_selection.go
+++ b/internal/provider/model_meraki_appliance_traffic_shaping_uplink_selection.go
@@ -22,8 +22,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"slices"
-	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -503,42 +501,18 @@ func (data *ApplianceTrafficShapingUplinkSelection) fromBodyPartial(ctx context.
 		} else {
 			data.PerformanceClassType = types.StringNull()
 		}
-		for i := 0; i < len(data.TrafficFilters); i++ {
-			keys := [...]string{"type", "value.id", "value.protocol", "value.destination.cidr", "value.destination.fqdn", "value.destination.host", "value.destination.network", "value.destination.port", "value.destination.vlan", "value.source.cidr", "value.source.host", "value.source.network", "value.source.port", "value.source.vlan"}
-			keyValues := [...]string{data.TrafficFilters[i].Type.ValueString(), data.TrafficFilters[i].Id.ValueString(), data.TrafficFilters[i].Protocol.ValueString(), data.TrafficFilters[i].DestinationCidr.ValueString(), data.TrafficFilters[i].DestinationFqdn.ValueString(), strconv.FormatInt(data.TrafficFilters[i].DestinationHost.ValueInt64(), 10), data.TrafficFilters[i].DestinationNetwork.ValueString(), data.TrafficFilters[i].DestinationPort.ValueString(), strconv.FormatInt(data.TrafficFilters[i].DestinationVlan.ValueInt64(), 10), data.TrafficFilters[i].SourceCidr.ValueString(), strconv.FormatInt(data.TrafficFilters[i].SourceHost.ValueInt64(), 10), data.TrafficFilters[i].SourceNetwork.ValueString(), data.TrafficFilters[i].SourcePort.ValueString(), strconv.FormatInt(data.TrafficFilters[i].SourceVlan.ValueInt64(), 10)}
-
+		{
+			l := len(res.Get("trafficFilters").Array())
+			tflog.Debug(ctx, fmt.Sprintf("trafficFilters array resizing from %d to %d", len(data.TrafficFilters), l))
+			if len(data.TrafficFilters) > l {
+				data.TrafficFilters = data.TrafficFilters[:l]
+			}
+		}
+		for i := range data.TrafficFilters {
 			parent := &data
 			data := (*parent).TrafficFilters[i]
 			parentRes := &res
-			var res gjson.Result
-
-			parentRes.Get("trafficFilters").ForEach(
-				func(_, v gjson.Result) bool {
-					found := false
-					for ik := range keys {
-						if v.Get(keys[ik]).String() != keyValues[ik] {
-							found = false
-							break
-						}
-						found = true
-					}
-					if found {
-						res = v
-						return false
-					}
-					return true
-				},
-			)
-			if !res.Exists() {
-				tflog.Debug(ctx, fmt.Sprintf("removing TrafficFilters[%d] = %+v",
-					i,
-					(*parent).TrafficFilters[i],
-				))
-				(*parent).TrafficFilters = slices.Delete((*parent).TrafficFilters, i, i+1)
-				i--
-
-				continue
-			}
+			res := parentRes.Get(fmt.Sprintf("trafficFilters.%d", i))
 			if value := res.Get("type"); value.Exists() && !data.Type.IsNull() {
 				data.Type = types.StringValue(value.String())
 			} else {
@@ -630,42 +604,18 @@ func (data *ApplianceTrafficShapingUplinkSelection) fromBodyPartial(ctx context.
 		} else {
 			data.PreferredUplink = types.StringNull()
 		}
-		for i := 0; i < len(data.TrafficFilters); i++ {
-			keys := [...]string{"type"}
-			keyValues := [...]string{data.TrafficFilters[i].Type.ValueString()}
-
+		{
+			l := len(res.Get("trafficFilters").Array())
+			tflog.Debug(ctx, fmt.Sprintf("trafficFilters array resizing from %d to %d", len(data.TrafficFilters), l))
+			if len(data.TrafficFilters) > l {
+				data.TrafficFilters = data.TrafficFilters[:l]
+			}
+		}
+		for i := range data.TrafficFilters {
 			parent := &data
 			data := (*parent).TrafficFilters[i]
 			parentRes := &res
-			var res gjson.Result
-
-			parentRes.Get("trafficFilters").ForEach(
-				func(_, v gjson.Result) bool {
-					found := false
-					for ik := range keys {
-						if v.Get(keys[ik]).String() != keyValues[ik] {
-							found = false
-							break
-						}
-						found = true
-					}
-					if found {
-						res = v
-						return false
-					}
-					return true
-				},
-			)
-			if !res.Exists() {
-				tflog.Debug(ctx, fmt.Sprintf("removing TrafficFilters[%d] = %+v",
-					i,
-					(*parent).TrafficFilters[i],
-				))
-				(*parent).TrafficFilters = slices.Delete((*parent).TrafficFilters, i, i+1)
-				i--
-
-				continue
-			}
+			res := parentRes.Get(fmt.Sprintf("trafficFilters.%d", i))
 			if value := res.Get("type"); value.Exists() && !data.Type.IsNull() {
 				data.Type = types.StringValue(value.String())
 			} else {

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -10,6 +10,7 @@ description: |-
 ## Unreleased
 
 - Fix issue with `stack_ids` attribute of `meraki_network_vlan_profile_assignment` resource, [link](https://github.com/CiscoDevNet/terraform-provider-meraki/issues/224)
+- Fix idempotency issue with `vpn_traffic_uplink_preferences[].traffic_filters`, `wan_traffic_uplink_preferences[].traffic_filters` attributes of `meraki_appliance_traffic_shaping_uplink_selection` resource, [link](https://github.com/CiscoDevNet/terraform-provider-meraki/pull/235)
 
 ## 1.12.1
 


### PR DESCRIPTION
- appliance_traffic_shaping_uplink_selection: trafficFilters: remove non-unique ID

    The definition YAML has "type" attribute as a unique ID,
    but it is not unique - multiple rules can have the same type.
    As a result, state refresh (`Read` -> `fromBodyPartial`)
    overwrites all items with the same "type" with the first one,
    making "terraform apply" always show a planned change -
    other items changing back to the configured values -
    even though they are already as configured in the API.

    Remove "id: true"
    so that items are matched based on all attributes instead.

- gen/templates: Allow using ordered_list at any depth

    Wherever OrderedList is used,
    it is part of a template that is executed recursively,
    so it is implemented at any depth.

- appliance_traffic_shaping_uplink_selection: trafficFilters: Use ordered_list

    `appliance_traffic_shaping_uplink_selection`'s
    `vpn_traffic_uplink_preferences[].traffic_filters[]`
    shows the whole list as newly added in the plan
    on every "terraform apply",
    even though it is already correctly applied in the API.

    `fromBodyPartial` (used on state refresh)
    matches every item from the state
    with one from the new API GET response
    and removes items which do not have a match from the state.
    The matching is either based on comparing all attributes
    or just the attribute with "id: true" in the definition if there is one.

    (gjson.Result).String() (from the parsed API response) is compared against
    either `<...>.ValueString()` (for strings)
    or `strconv.FormatInt(<...>.ValueInt64(), 10)` (for `int64`s)
    or `strconv.FormatBool(<...>.ValueBool())` (for `bool`s)

    For int64 attributes missing in the API response
    (in this case, e.g. `sourceHost` which is optional),
    the former (from the API) produces `""`
    while the latter (from the state) produces `"0"`,
    so the comparison always fails
    and the items without the attribute get removed on state refresh,
    making the plan always show the config as not applied.

    Changing the comparison's behavior would fix the issue for
    `appliance_traffic_shaping_uplink_selection`,
    but changing bool comparison to be consistent with that
    would break idempotency for
    `cellular_gateway_connectivity_monitoring_destinations`,
    as the API replaces unset `default` attribute with `false`
    (so a comparison with `null` would always fail).
    There might be similar issues with other resources.

    Use `ordered_list: true`
    just for `appliance_traffic_shaping_uplink_selection` instead -
    the API does not reorder the items
    (if the user does not remove and re-add them in the UI/API manually),
    so this behavior is fine.

- appliance_sdwan_internet_policies: Use ordered_list

    Use `ordered_list` instead of marking the non-unique `type`
    attribute as the key in `trafficFilters`
    to match the similar schema in
    `appliance_traffic_shaping_uplink_selection`.

    This resource has `no_read: true`
    (at least until the GET endpoint becomes non-early-access in the API),
    so this doesn't change the behavior.

Testing (`meraki_appliance_traffic_shaping_uplink_selection` `vpn_uplink_preferences`):
- [x] Reproduce #230 and confirm subsequent plans show no changes once applied once.
- [x] Manually change a traffic filter in UI and confirm Terraform detects the drift on state refresh.
- [x] Manually add an extra traffic filter in UI and confirm Terraform still (incorrectly) does not detect the drift.

Fixes #230