### PR TITLE
Fix upgrade_window_day_of_week enum values to match API casing

### DIFF
--- a/docs/resources/network_firmware_upgrades.md
+++ b/docs/resources/network_firmware_upgrades.md
@@ -43,7 +43,7 @@ resource "meraki_network_firmware_upgrades" "example" {
   products_wireless_controller_participate_in_next_beta_release = false
   products_wireless_controller_next_upgrade_time                = "2019-03-17T17:22:52Z"
   products_wireless_controller_next_upgrade_to_version_id       = "1006"
-  upgrade_window_day_of_week                                    = "sun"
+  upgrade_window_day_of_week                                    = "Sun"
   upgrade_window_hour_of_day                                    = "4:00"
 }
 ```
@@ -86,7 +86,7 @@ resource "meraki_network_firmware_upgrades" "example" {
 - `products_wireless_participate_in_next_beta_release` (Boolean) Whether or not the network wants beta firmware
 - `timezone` (String) The timezone for the network
 - `upgrade_window_day_of_week` (String) Day of the week
-  - Choices: `fri`, `friday`, `mon`, `monday`, `sat`, `saturday`, `sun`, `sunday`, `thu`, `thursday`, `tue`, `tuesday`, `wed`, `wednesday`
+  - Choices: `Fri`, `Friday`, `Mon`, `Monday`, `Sat`, `Saturday`, `Sun`, `Sunday`, `Thu`, `Thursday`, `Tue`, `Tuesday`, `Wed`, `Wednesday`
 - `upgrade_window_hour_of_day` (String) Hour of the day
   - Choices: `0:00`, `10:00`, `11:00`, `12:00`, `13:00`, `14:00`, `15:00`, `16:00`, `17:00`, `18:00`, `19:00`, `1:00`, `20:00`, `21:00`, `22:00`, `23:00`, `2:00`, `3:00`, `4:00`, `5:00`, `6:00`, `7:00`, `8:00`, `9:00`
 

--- a/examples/resources/meraki_network_firmware_upgrades/resource.tf
+++ b/examples/resources/meraki_network_firmware_upgrades/resource.tf
@@ -28,6 +28,6 @@ resource "meraki_network_firmware_upgrades" "example" {
   products_wireless_controller_participate_in_next_beta_release = false
   products_wireless_controller_next_upgrade_time                = "2019-03-17T17:22:52Z"
   products_wireless_controller_next_upgrade_to_version_id       = "1006"
-  upgrade_window_day_of_week                                    = "sun"
+  upgrade_window_day_of_week                                    = "Sun"
   upgrade_window_hour_of_day                                    = "4:00"
 }

--- a/gen/definitions/network_firmware_upgrades.yaml
+++ b/gen/definitions/network_firmware_upgrades.yaml
@@ -158,8 +158,8 @@ attributes:
     type: String
     data_path: [upgradeWindow]
     description: Day of the week
-    example: sun
-    enum_values: [fri, friday, mon, monday, sat, saturday, sun, sunday, thu, thursday, tue, tuesday, wed, wednesday]
+    example: Sun
+    enum_values: [Fri, Friday, Mon, Monday, Sat, Saturday, Sun, Sunday, Thu, Thursday, Tue, Tuesday, Wed, Wednesday]
   - model_name: hourOfDay
     type: String
     data_path: [upgradeWindow]

--- a/internal/provider/data_source_meraki_network_firmware_upgrades_test.go
+++ b/internal/provider/data_source_meraki_network_firmware_upgrades_test.go
@@ -65,7 +65,7 @@ func TestAccDataSourceMerakiNetworkFirmwareUpgrades(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.meraki_network_firmware_upgrades.test", "products_wireless_controller_participate_in_next_beta_release", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.meraki_network_firmware_upgrades.test", "products_wireless_controller_next_upgrade_time", "2019-03-17T17:22:52Z"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.meraki_network_firmware_upgrades.test", "products_wireless_controller_next_upgrade_to_version_id", "1006"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.meraki_network_firmware_upgrades.test", "upgrade_window_day_of_week", "sun"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.meraki_network_firmware_upgrades.test", "upgrade_window_day_of_week", "Sun"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.meraki_network_firmware_upgrades.test", "upgrade_window_hour_of_day", "4:00"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -132,7 +132,7 @@ func testAccDataSourceMerakiNetworkFirmwareUpgradesConfig() string {
 	config += `  products_wireless_controller_participate_in_next_beta_release = false` + "\n"
 	config += `  products_wireless_controller_next_upgrade_time = "2019-03-17T17:22:52Z"` + "\n"
 	config += `  products_wireless_controller_next_upgrade_to_version_id = "1006"` + "\n"
-	config += `  upgrade_window_day_of_week = "sun"` + "\n"
+	config += `  upgrade_window_day_of_week = "Sun"` + "\n"
 	config += `  upgrade_window_hour_of_day = "4:00"` + "\n"
 	config += `}` + "\n"
 

--- a/internal/provider/resource_meraki_network_firmware_upgrades.go
+++ b/internal/provider/resource_meraki_network_firmware_upgrades.go
@@ -192,10 +192,10 @@ func (r *NetworkFirmwareUpgradesResource) Schema(ctx context.Context, req resour
 				Optional:            true,
 			},
 			"upgrade_window_day_of_week": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Day of the week").AddStringEnumDescription("fri", "friday", "mon", "monday", "sat", "saturday", "sun", "sunday", "thu", "thursday", "tue", "tuesday", "wed", "wednesday").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Day of the week").AddStringEnumDescription("Fri", "Friday", "Mon", "Monday", "Sat", "Saturday", "Sun", "Sunday", "Thu", "Thursday", "Tue", "Tuesday", "Wed", "Wednesday").String,
 				Optional:            true,
 				Validators: []validator.String{
-					stringvalidator.OneOf("fri", "friday", "mon", "monday", "sat", "saturday", "sun", "sunday", "thu", "thursday", "tue", "tuesday", "wed", "wednesday"),
+					stringvalidator.OneOf("Fri", "Friday", "Mon", "Monday", "Sat", "Saturday", "Sun", "Sunday", "Thu", "Thursday", "Tue", "Tuesday", "Wed", "Wednesday"),
 				},
 			},
 			"upgrade_window_hour_of_day": schema.StringAttribute{

--- a/internal/provider/resource_meraki_network_firmware_upgrades_test.go
+++ b/internal/provider/resource_meraki_network_firmware_upgrades_test.go
@@ -69,7 +69,7 @@ func TestAccMerakiNetworkFirmwareUpgrades(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("meraki_network_firmware_upgrades.test", "products_wireless_controller_participate_in_next_beta_release", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("meraki_network_firmware_upgrades.test", "products_wireless_controller_next_upgrade_time", "2019-03-17T17:22:52Z"))
 	checks = append(checks, resource.TestCheckResourceAttr("meraki_network_firmware_upgrades.test", "products_wireless_controller_next_upgrade_to_version_id", "1006"))
-	checks = append(checks, resource.TestCheckResourceAttr("meraki_network_firmware_upgrades.test", "upgrade_window_day_of_week", "sun"))
+	checks = append(checks, resource.TestCheckResourceAttr("meraki_network_firmware_upgrades.test", "upgrade_window_day_of_week", "Sun"))
 	checks = append(checks, resource.TestCheckResourceAttr("meraki_network_firmware_upgrades.test", "upgrade_window_hour_of_day", "4:00"))
 
 	var steps []resource.TestStep
@@ -179,7 +179,7 @@ func testAccMerakiNetworkFirmwareUpgradesConfig_all() string {
 	config += `  products_wireless_controller_participate_in_next_beta_release = false` + "\n"
 	config += `  products_wireless_controller_next_upgrade_time = "2019-03-17T17:22:52Z"` + "\n"
 	config += `  products_wireless_controller_next_upgrade_to_version_id = "1006"` + "\n"
-	config += `  upgrade_window_day_of_week = "sun"` + "\n"
+	config += `  upgrade_window_day_of_week = "Sun"` + "\n"
 	config += `  upgrade_window_hour_of_day = "4:00"` + "\n"
 	config += `}` + "\n"
 	return config


### PR DESCRIPTION
Fixes #248.

The Dashboard API sometimes returns enum values in a different casing than the documented enum values the schema validators accept — `upgradeWindow.dayOfWeek` on `/networks/{networkId}/firmwareUpgrades` returns `"Sun"` where the schema allows `"sun"`. State then holds a value that configuration is not allowed to express: `terraform plan -generate-config-out` fails validation on its own output, and hand-lowercasing the config produces a case-flip diff that never converges (details and repro in #248).

This PR makes the generated Read paths map enum attribute values onto the documented enum values case-insensitively:

- new `helpers.NormalizeEnum(value, allowed...)` — returns the exact match if present, otherwise the first case-insensitive match, otherwise the value unchanged (so unrecognized API values still surface as-is)
- the model templates (`fromBody`, `fromBodyPartial`, `fromBodyUnknowns`, and the bulk equivalents) wrap enum-valued string reads with it
- regenerated code for the affected models; unit test for the helper

Verified against a live organization: importing `meraki_network_firmware_upgrades` with `-generate-config-out` now succeeds and the day-of-week attribute converges. (The only remaining plan noise on that resource is the pre-existing `""` → `null` on `products_*_next_upgrade_time`, unrelated to enums.)

I kept the scope to casing only — synonym spellings (`monday` vs `mon`) still round-trip to the API's spelling, same as before.
