### PR TITLE
appliance_traffic_shaping_uplink_selection: Clear wanTrafficUplinkPreferences only if configured

### DIFF
--- a/internal/provider/resource_meraki_appliance_traffic_shaping_uplink_selection.go
+++ b/internal/provider/resource_meraki_appliance_traffic_shaping_uplink_selection.go
@@ -463,19 +463,21 @@ func (r *ApplianceTrafficShapingUplinkSelectionResource) Delete(ctx context.Cont
 		}
 	}
 
-	// Clear the shared wanTrafficUplinkPreferences
-	// by PUTting "wanTrafficUplinkPreferences": []
-	// to appliance/sdwan/internetPolicies endpoint,
-	// as PUTting "wanTrafficUplinkPreferences": []
-	// to appliance/trafficShaping/uplinkSelection endpoint does nothing.
-	sdwanInternetPolicies := ApplianceSDWANInternetPolicies{
-		NetworkId: state.NetworkId,
-	}
-	body, _ := sjson.Set("", "wanTrafficUplinkPreferences", []interface{}{})
-	res, err := r.client.Put(sdwanInternetPolicies.getPath(), body)
-	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to clear Appliance Traffic Shaping Uplink Preferences wan_traffic_uplink_preferences via Appliance SDWAN Internet Policies endpoint (PUT), got error: %s, %s", err, res.String()))
-		return
+	if len(state.WanTrafficUplinkPreferences) > 0 {
+		// Clear the shared wanTrafficUplinkPreferences
+		// by PUTting "wanTrafficUplinkPreferences": []
+		// to appliance/sdwan/internetPolicies endpoint,
+		// as PUTting "wanTrafficUplinkPreferences": []
+		// to appliance/trafficShaping/uplinkSelection endpoint does nothing.
+		sdwanInternetPolicies := ApplianceSDWANInternetPolicies{
+			NetworkId: state.NetworkId,
+		}
+		body, _ := sjson.Set("", "wanTrafficUplinkPreferences", []interface{}{})
+		res, err := r.client.Put(sdwanInternetPolicies.getPath(), body)
+		if err != nil {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to clear Appliance Traffic Shaping Uplink Preferences wan_traffic_uplink_preferences via Appliance SDWAN Internet Policies endpoint (PUT), got error: %s, %s", err, res.String()))
+			return
+		}
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("%s: Delete finished successfully", state.Id.ValueString()))


### PR DESCRIPTION
wanTrafficUplinkPreferences is cleared on Delete
via the SDWAN internet policies endpoint
as clearing it via uplink preferences endpoint has no effect (#84).

That endpoint can return an error like the following with MX64 devices:

```
│ Error: Client Error
│
│ Failed to clear Appliance Traffic Shaping Uplink Preferences wan_traffic_uplink_preferences via Appliance SDWAN Internet Policies endpoint (PUT), got error: │ HTTP Request failed: StatusCode 400, JSON error: ["Endpoint only supported for networks on version >=18.2"], {"errors":["Endpoint only supported for networks on │ version >=18.2"]}
```

Work around this by only trying to use the endpoint if wanTrafficUplinkPreferences were configured.
This would not fix the issue if they were actually used, but at least prevents the error on "terraform destroy" if they weren't.

TODO Test if `wanTrafficUplinkPreferences` are allowed at all in uplink selection endpoint on these devices. If they are allowed, that would mean they cannot be cleared at all with these devices.
TODO Update the changelog.