### PR TITLE
fix: port_ids idempotency and fallbackProfile null-clear for automation resource

### DIFF
--- a/docs/data-sources/switch_organization_ports_profiles_automation.md
+++ b/docs/data-sources/switch_organization_ports_profiles_automation.md
@@ -47,7 +47,7 @@ data "meraki_switch_organization_ports_profiles_automation" "example" {
 
 Read-Only:
 
-- `port_ids` (List of String) List of port ids
+- `port_ids` (Set of String) List of port ids
 - `switch_serial` (String) Serial number of the switch
 
 

--- a/docs/data-sources/switch_organization_ports_profiles_automations.md
+++ b/docs/data-sources/switch_organization_ports_profiles_automations.md
@@ -50,7 +50,7 @@ Read-Only:
 
 Read-Only:
 
-- `port_ids` (List of String) List of port ids
+- `port_ids` (Set of String) List of port ids
 - `switch_serial` (String) Serial number of the switch
 
 

--- a/docs/resources/switch_organization_ports_profiles_automation.md
+++ b/docs/resources/switch_organization_ports_profiles_automation.md
@@ -91,7 +91,7 @@ Required:
 
 Optional:
 
-- `port_ids` (List of String) List of port ids
+- `port_ids` (Set of String) List of port ids
 - `switch_serial` (String) Serial number of the switch
 
 ## Import

--- a/gen/definitions/switch_organization_ports_profiles_automation.yaml
+++ b/gen/definitions/switch_organization_ports_profiles_automation.yaml
@@ -29,12 +29,14 @@ attributes:
     type: String
     data_path: [fallbackProfile]
     exclude_test: true
+    send_null_on_clear: true
     description: Default port profile Id
     example: "1284392014819"
   - model_name: name
     type: String
     data_path: [fallbackProfile]
     exclude_test: true
+    send_null_on_clear: true
     description: Default port profile name
     example: Profile 1
   - model_name: assignedSwitchPorts
@@ -48,7 +50,7 @@ attributes:
         example: Q234-ABCD-5678
         test_value: tolist(meraki_network_device_claim.test.serials)[0]
       - model_name: portIds
-        type: List
+        type: Set
         element_type: String
         description: List of port ids
         example: "3"

--- a/gen/definitions/switch_organization_ports_profiles_automation.yaml
+++ b/gen/definitions/switch_organization_ports_profiles_automation.yaml
@@ -28,15 +28,15 @@ attributes:
   - model_name: id
     type: String
     data_path: [fallbackProfile]
-    exclude_test: true
     send_null_on_clear: true
+    exclude_test: true
     description: Default port profile Id
     example: "1284392014819"
   - model_name: name
     type: String
     data_path: [fallbackProfile]
-    exclude_test: true
     send_null_on_clear: true
+    exclude_test: true
     description: Default port profile name
     example: Profile 1
   - model_name: assignedSwitchPorts

--- a/gen/schema/schema.yaml
+++ b/gen/schema/schema.yaml
@@ -47,6 +47,7 @@ attribute:
   write_only: bool(required=False) # Set to true if the attribute is write-only, meaning we cannot read the value
   data_source_only: bool(required=False) # Set to true if the attribute should only be present in the data source, not the resource (e.g. GET-only detail not accepted by the PUT/POST body). Cascades to nested attributes.
   write_changes_only: bool(required=False) # Set to true if the attribute should only be written (included in PUT payload) if it has changed
+  send_null_on_clear: bool(required=False) # Set to true if a null value in the plan (field removed from config) should be sent as JSON null to the API, clearing the field. Without this, omitting the field from the PUT body leaves the API value unchanged.
   sensitive: bool(required=False)  # Set to true if the attribute is sensitive, meaning it should not show up in clear-text in plan and logs
   write_empty_list: bool(required=False) # Set to true if the attribute should be written as an empty list if it is not set, only relevant if type is "List" or "Set"
   exclude_test: bool(required=False) # Exclude attribute from example (documentation) and acceptance test

--- a/gen/templates/model_resource.go
+++ b/gen/templates/model_resource.go
@@ -179,7 +179,9 @@ func (data {{camelCase .Name}}) toBody(ctx context.Context, state {{camelCase .N
 	{{- else if or (eq .Type "String") (eq .Type "Int64") (eq .Type "Float64") (eq .Type "Bool")}}
 	if !data.{{toGoName .TfName}}.IsNull() {{if .WriteChangesOnly}}&& data.{{toGoName .TfName}} != state.{{toGoName .TfName}}{{end}} {
 		body, _ = sjson.Set(body, "{{getFullModelName . true}}", data.{{toGoName .TfName}}.Value{{.Type}}())
-	}
+	}{{if .SendNullOnClear}} else if !state.{{toGoName .TfName}}.IsNull() {
+		body, _ = sjson.Set(body, "{{getFullModelName . true}}", nil)
+	}{{end}}
 	{{- else if isListSet .}}
 	if !data.{{toGoName .TfName}}.IsNull() {
 		var values []{{if isStringListSet .}}string{{else if isInt64ListSet .}}int64{{end}}

--- a/gen/yamlconfig/main.go
+++ b/gen/yamlconfig/main.go
@@ -103,6 +103,7 @@ type YamlConfigAttribute struct {
 	WriteOnly          bool                  `yaml:"write_only,omitempty"`
 	DataSourceOnly     bool                  `yaml:"data_source_only,omitempty"`
 	WriteChangesOnly   bool                  `yaml:"write_changes_only,omitempty"`
+	SendNullOnClear    bool                  `yaml:"send_null_on_clear,omitempty"`
 	Sensitive          bool                  `yaml:"sensitive,omitempty"`
 	WriteEmptyList     bool                  `yaml:"write_empty_list,omitempty"`
 	ExcludeTest        bool                  `yaml:"exclude_test,omitempty"`
@@ -149,6 +150,7 @@ type YamlConfigAttributeP struct {
 	WriteOnly          *bool                   `yaml:"write_only,omitempty"`
 	DataSourceOnly     *bool                   `yaml:"data_source_only,omitempty"`
 	WriteChangesOnly   *bool                   `yaml:"write_changes_only,omitempty"`
+	SendNullOnClear    *bool                   `yaml:"send_null_on_clear,omitempty"`
 	Sensitive          *bool                   `yaml:"sensitive,omitempty"`
 	WriteEmptyList     *bool                   `yaml:"write_empty_list,omitempty"`
 	ExcludeTest        *bool                   `yaml:"exclude_test,omitempty"`
@@ -693,6 +695,9 @@ func (attr *YamlConfigAttribute) Init(parentGoTypeName, parentGoTypeBulkName str
 		if attr.WriteChangesOnly {
 			return fmt.Errorf("%q: `data_source_only` cannot be combined with `write_changes_only`, since that only applies to the resource's PUT body diffing", attr.TfName)
 		}
+		if attr.SendNullOnClear {
+			return fmt.Errorf("%q: `data_source_only` cannot be combined with `send_null_on_clear`, since that only applies to the resource's PUT body clearing", attr.TfName)
+		}
 		if attr.WriteOnly {
 			return fmt.Errorf("%q: `data_source_only` cannot be combined with `write_only`, they are opposites (write-only means unreadable, data-source-only means unwritable)", attr.TfName)
 		}
@@ -970,6 +975,9 @@ func MergeYamlConfigAttribute(existing *YamlConfigAttributeP, new *YamlConfigAtt
 	}
 	if existing.WriteChangesOnly != nil {
 		new.WriteChangesOnly = existing.WriteChangesOnly
+	}
+	if existing.SendNullOnClear != nil {
+		new.SendNullOnClear = existing.SendNullOnClear
 	}
 	if existing.Sensitive != nil {
 		new.Sensitive = existing.Sensitive

--- a/internal/provider/data_source_meraki_switch_organization_ports_profiles_automation.go
+++ b/internal/provider/data_source_meraki_switch_organization_ports_profiles_automation.go
@@ -97,7 +97,7 @@ func (d *SwitchOrganizationPortsProfilesAutomationDataSource) Schema(ctx context
 							MarkdownDescription: "Serial number of the switch",
 							Computed:            true,
 						},
-						"port_ids": schema.ListAttribute{
+						"port_ids": schema.SetAttribute{
 							MarkdownDescription: "List of port ids",
 							ElementType:         types.StringType,
 							Computed:            true,

--- a/internal/provider/data_source_meraki_switch_organization_ports_profiles_automation_test.go
+++ b/internal/provider/data_source_meraki_switch_organization_ports_profiles_automation_test.go
@@ -36,7 +36,6 @@ func TestAccDataSourceMerakiSwitchOrganizationPortsProfilesAutomation(t *testing
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("data.meraki_switch_organization_ports_profiles_automation.test", "description", "A full length description of the automation."))
 	checks = append(checks, resource.TestCheckResourceAttr("data.meraki_switch_organization_ports_profiles_automation.test", "name", "Automation 1"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.meraki_switch_organization_ports_profiles_automation.test", "assigned_switch_ports.0.port_ids.0", "3"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.meraki_switch_organization_ports_profiles_automation.test", "rules.0.priority", "1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.meraki_switch_organization_ports_profiles_automation.test", "rules.0.conditions.0.attribute", "LLDP system description"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.meraki_switch_organization_ports_profiles_automation.test", "rules.0.conditions.0.values.0", "Meraki MR*"))

--- a/internal/provider/data_source_meraki_switch_organization_ports_profiles_automations.go
+++ b/internal/provider/data_source_meraki_switch_organization_ports_profiles_automations.go
@@ -96,7 +96,7 @@ func (d *SwitchOrganizationPortsProfilesAutomationsDataSource) Schema(ctx contex
 										MarkdownDescription: "Serial number of the switch",
 										Computed:            true,
 									},
-									"port_ids": schema.ListAttribute{
+									"port_ids": schema.SetAttribute{
 										MarkdownDescription: "List of port ids",
 										ElementType:         types.StringType,
 										Computed:            true,

--- a/internal/provider/model_data_source_meraki_switch_organization_ports_profiles_automation.go
+++ b/internal/provider/model_data_source_meraki_switch_organization_ports_profiles_automation.go
@@ -54,7 +54,7 @@ type DataSourceSwitchOrganizationPortsProfilesAutomation struct {
 
 type DataSourceSwitchOrganizationPortsProfilesAutomationAssignedSwitchPorts struct {
 	SwitchSerial types.String `tfsdk:"switch_serial"`
-	PortIds      types.List   `tfsdk:"port_ids"`
+	PortIds      types.Set    `tfsdk:"port_ids"`
 }
 
 type DataSourceSwitchOrganizationPortsProfilesAutomationRules struct {
@@ -113,9 +113,9 @@ func (data *DataSourceSwitchOrganizationPortsProfilesAutomation) fromBody(ctx co
 				data.SwitchSerial = types.StringNull()
 			}
 			if value := res.Get("portIds"); value.Exists() && value.Value() != nil {
-				data.PortIds = helpers.GetStringList(value.Array())
+				data.PortIds = helpers.GetStringSet(value.Array())
 			} else {
-				data.PortIds = types.ListNull(types.StringType)
+				data.PortIds = types.SetNull(types.StringType)
 			}
 			(*parent).AssignedSwitchPorts = append((*parent).AssignedSwitchPorts, data)
 			return true

--- a/internal/provider/model_data_source_meraki_switch_organization_ports_profiles_automations.go
+++ b/internal/provider/model_data_source_meraki_switch_organization_ports_profiles_automations.go
@@ -50,7 +50,7 @@ type DataSourceSwitchOrganizationPortsProfilesAutomationsItems struct {
 
 type DataSourceSwitchOrganizationPortsProfilesAutomationsAssignedSwitchPorts struct {
 	SwitchSerial types.String `tfsdk:"switch_serial"`
-	PortIds      types.List   `tfsdk:"port_ids"`
+	PortIds      types.Set    `tfsdk:"port_ids"`
 }
 
 type DataSourceSwitchOrganizationPortsProfilesAutomationsRules struct {
@@ -114,9 +114,9 @@ func (data *DataSourceSwitchOrganizationPortsProfilesAutomations) fromBody(ctx c
 					data.SwitchSerial = types.StringNull()
 				}
 				if value := res.Get("portIds"); value.Exists() && value.Value() != nil {
-					data.PortIds = helpers.GetStringList(value.Array())
+					data.PortIds = helpers.GetStringSet(value.Array())
 				} else {
-					data.PortIds = types.ListNull(types.StringType)
+					data.PortIds = types.SetNull(types.StringType)
 				}
 				(*parent).AssignedSwitchPorts = append((*parent).AssignedSwitchPorts, data)
 				return true

--- a/internal/provider/model_resource_meraki_switch_organization_ports_profiles_automation.go
+++ b/internal/provider/model_resource_meraki_switch_organization_ports_profiles_automation.go
@@ -38,36 +38,65 @@ import (
 // Section below is generated&owned by "gen/generator.go". //template:begin types
 
 type SwitchOrganizationPortsProfilesAutomation struct {
-	Id                  types.String                                                   `tfsdk:"id"`
-	OrganizationId      types.String                                                   `tfsdk:"organization_id"`
-	Description         types.String                                                   `tfsdk:"description"`
-	Name                types.String                                                   `tfsdk:"name"`
-	FallbackProfileId   types.String                                                   `tfsdk:"fallback_profile_id"`
-	FallbackProfileName types.String                                                   `tfsdk:"fallback_profile_name"`
+	Id types.String `tfsdk:"id"`
+	OrganizationId types.String `tfsdk:"organization_id"`
+	Description types.String `tfsdk:"description"`
+	Name types.String `tfsdk:"name"`
+	FallbackProfileId types.String `tfsdk:"fallback_profile_id"`
+	FallbackProfileName types.String `tfsdk:"fallback_profile_name"`
 	AssignedSwitchPorts []SwitchOrganizationPortsProfilesAutomationAssignedSwitchPorts `tfsdk:"assigned_switch_ports"`
-	Rules               []SwitchOrganizationPortsProfilesAutomationRules               `tfsdk:"rules"`
+	Rules []SwitchOrganizationPortsProfilesAutomationRules `tfsdk:"rules"`
 }
+
+
+
+
+
+
 
 type SwitchOrganizationPortsProfilesAutomationAssignedSwitchPorts struct {
 	SwitchSerial types.String `tfsdk:"switch_serial"`
-	PortIds      types.List   `tfsdk:"port_ids"`
+	PortIds types.Set `tfsdk:"port_ids"`
 }
 
 type SwitchOrganizationPortsProfilesAutomationRules struct {
-	Priority    types.Int64                                                `tfsdk:"priority"`
-	ProfileId   types.String                                               `tfsdk:"profile_id"`
-	ProfileName types.String                                               `tfsdk:"profile_name"`
-	Conditions  []SwitchOrganizationPortsProfilesAutomationRulesConditions `tfsdk:"conditions"`
+	Priority types.Int64 `tfsdk:"priority"`
+	ProfileId types.String `tfsdk:"profile_id"`
+	ProfileName types.String `tfsdk:"profile_name"`
+	Conditions []SwitchOrganizationPortsProfilesAutomationRulesConditions `tfsdk:"conditions"`
 }
+
+
+
+
+
+
+
+
+
+
 
 type SwitchOrganizationPortsProfilesAutomationRulesConditions struct {
 	Attribute types.String `tfsdk:"attribute"`
-	Values    types.List   `tfsdk:"values"`
+	Values types.List `tfsdk:"values"`
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 type SwitchOrganizationPortsProfilesAutomationIdentity struct {
 	OrganizationId types.String `tfsdk:"organization_id"`
-	Id             types.String `tfsdk:"id"`
+	Id types.String `tfsdk:"id"`
 }
 
 // End of section. //template:end types
@@ -75,7 +104,7 @@ type SwitchOrganizationPortsProfilesAutomationIdentity struct {
 // Section below is generated&owned by "gen/generator.go". //template:begin getPath
 
 func (data SwitchOrganizationPortsProfilesAutomation) getPath() string {
-	return fmt.Sprintf("/organizations/%v/switch/ports/profiles/automations", url.QueryEscape(data.OrganizationId.ValueString()))
+		return fmt.Sprintf("/organizations/%v/switch/ports/profiles/automations", url.QueryEscape(data.OrganizationId.ValueString()))
 }
 
 // End of section. //template:end getPath
@@ -84,17 +113,21 @@ func (data SwitchOrganizationPortsProfilesAutomation) getPath() string {
 
 func (data SwitchOrganizationPortsProfilesAutomation) toBody(ctx context.Context, state SwitchOrganizationPortsProfilesAutomation) string {
 	body := ""
-	if !data.Description.IsNull() {
+	if !data.Description.IsNull()  {
 		body, _ = sjson.Set(body, "description", data.Description.ValueString())
 	}
-	if !data.Name.IsNull() {
+	if !data.Name.IsNull()  {
 		body, _ = sjson.Set(body, "name", data.Name.ValueString())
 	}
-	if !data.FallbackProfileId.IsNull() {
+	if !data.FallbackProfileId.IsNull()  {
 		body, _ = sjson.Set(body, "fallbackProfile.id", data.FallbackProfileId.ValueString())
+	} else if !state.FallbackProfileId.IsNull() {
+		body, _ = sjson.Set(body, "fallbackProfile.id", nil)
 	}
-	if !data.FallbackProfileName.IsNull() {
+	if !data.FallbackProfileName.IsNull()  {
 		body, _ = sjson.Set(body, "fallbackProfile.name", data.FallbackProfileName.ValueString())
+	} else if !state.FallbackProfileName.IsNull() {
+		body, _ = sjson.Set(body, "fallbackProfile.name", nil)
 	}
 	if len(data.AssignedSwitchPorts) > 0 {
 		body, _ = sjson.Set(body, "assignedSwitchPorts", []interface{}{})
@@ -175,16 +208,16 @@ func (data *SwitchOrganizationPortsProfilesAutomation) fromBody(ctx context.Cont
 		value.ForEach(func(k, res gjson.Result) bool {
 			parent := &data
 			data := SwitchOrganizationPortsProfilesAutomationAssignedSwitchPorts{}
-			if value := res.Get("switch.serial"); value.Exists() && value.Value() != nil {
-				data.SwitchSerial = types.StringValue(value.String())
-			} else {
-				data.SwitchSerial = types.StringNull()
-			}
-			if value := res.Get("portIds"); value.Exists() && value.Value() != nil {
-				data.PortIds = helpers.GetStringList(value.Array())
-			} else {
-				data.PortIds = types.ListNull(types.StringType)
-			}
+	if value := res.Get("switch.serial"); value.Exists() && value.Value() != nil {
+		data.SwitchSerial = types.StringValue(value.String())
+	} else {
+		data.SwitchSerial = types.StringNull()
+	}
+	if value := res.Get("portIds"); value.Exists() && value.Value() != nil {
+		data.PortIds = helpers.GetStringSet(value.Array())
+	} else {
+		data.PortIds = types.SetNull(types.StringType)
+	}
 			(*parent).AssignedSwitchPorts = append((*parent).AssignedSwitchPorts, data)
 			return true
 		})
@@ -194,40 +227,40 @@ func (data *SwitchOrganizationPortsProfilesAutomation) fromBody(ctx context.Cont
 		value.ForEach(func(k, res gjson.Result) bool {
 			parent := &data
 			data := SwitchOrganizationPortsProfilesAutomationRules{}
-			if value := res.Get("priority"); value.Exists() && value.Value() != nil {
-				data.Priority = types.Int64Value(value.Int())
-			} else {
-				data.Priority = types.Int64Null()
-			}
-			if value := res.Get("profile.id"); value.Exists() && value.Value() != nil {
-				data.ProfileId = types.StringValue(value.String())
-			} else {
-				data.ProfileId = types.StringNull()
-			}
-			if value := res.Get("profile.name"); value.Exists() && value.Value() != nil {
-				data.ProfileName = types.StringValue(value.String())
-			} else {
-				data.ProfileName = types.StringNull()
-			}
-			if value := res.Get("conditions"); value.Exists() && value.Value() != nil {
-				data.Conditions = make([]SwitchOrganizationPortsProfilesAutomationRulesConditions, 0)
-				value.ForEach(func(k, res gjson.Result) bool {
-					parent := &data
-					data := SwitchOrganizationPortsProfilesAutomationRulesConditions{}
-					if value := res.Get("attribute"); value.Exists() && value.Value() != nil {
-						data.Attribute = types.StringValue(value.String())
-					} else {
-						data.Attribute = types.StringNull()
-					}
-					if value := res.Get("values"); value.Exists() && value.Value() != nil {
-						data.Values = helpers.GetStringList(value.Array())
-					} else {
-						data.Values = types.ListNull(types.StringType)
-					}
-					(*parent).Conditions = append((*parent).Conditions, data)
-					return true
-				})
-			}
+	if value := res.Get("priority"); value.Exists() && value.Value() != nil {
+		data.Priority = types.Int64Value(value.Int())
+	} else {
+		data.Priority = types.Int64Null()
+	}
+	if value := res.Get("profile.id"); value.Exists() && value.Value() != nil {
+		data.ProfileId = types.StringValue(value.String())
+	} else {
+		data.ProfileId = types.StringNull()
+	}
+	if value := res.Get("profile.name"); value.Exists() && value.Value() != nil {
+		data.ProfileName = types.StringValue(value.String())
+	} else {
+		data.ProfileName = types.StringNull()
+	}
+	if value := res.Get("conditions"); value.Exists() && value.Value() != nil {
+		data.Conditions = make([]SwitchOrganizationPortsProfilesAutomationRulesConditions, 0)
+		value.ForEach(func(k, res gjson.Result) bool {
+			parent := &data
+			data := SwitchOrganizationPortsProfilesAutomationRulesConditions{}
+	if value := res.Get("attribute"); value.Exists() && value.Value() != nil {
+		data.Attribute = types.StringValue(value.String())
+	} else {
+		data.Attribute = types.StringNull()
+	}
+	if value := res.Get("values"); value.Exists() && value.Value() != nil {
+		data.Values = helpers.GetStringList(value.Array())
+	} else {
+		data.Values = types.ListNull(types.StringType)
+	}
+			(*parent).Conditions = append((*parent).Conditions, data)
+			return true
+		})
+	}
 			(*parent).Rules = append((*parent).Rules, data)
 			return true
 		})
@@ -264,8 +297,8 @@ func (data *SwitchOrganizationPortsProfilesAutomation) fromBodyPartial(ctx conte
 		data.FallbackProfileName = types.StringNull()
 	}
 	for i := 0; i < len(data.AssignedSwitchPorts); i++ {
-		keys := [...]string{"switch.serial"}
-		keyValues := [...]string{data.AssignedSwitchPorts[i].SwitchSerial.ValueString()}
+		keys := [...]string{ "switch.serial",  }
+		keyValues := [...]string{ data.AssignedSwitchPorts[i].SwitchSerial.ValueString(),  }
 
 		parent := &data
 		data := (*parent).AssignedSwitchPorts[i]
@@ -299,21 +332,21 @@ func (data *SwitchOrganizationPortsProfilesAutomation) fromBodyPartial(ctx conte
 
 			continue
 		}
-		if value := res.Get("switch.serial"); value.Exists() && !data.SwitchSerial.IsNull() {
-			data.SwitchSerial = types.StringValue(value.String())
-		} else {
-			data.SwitchSerial = types.StringNull()
-		}
-		if value := res.Get("portIds"); value.Exists() && !data.PortIds.IsNull() {
-			data.PortIds = helpers.GetStringList(value.Array())
-		} else {
-			data.PortIds = types.ListNull(types.StringType)
-		}
+	if value := res.Get("switch.serial"); value.Exists() && !data.SwitchSerial.IsNull() {
+		data.SwitchSerial = types.StringValue(value.String())
+	} else {
+		data.SwitchSerial = types.StringNull()
+	}
+	if value := res.Get("portIds"); value.Exists() && !data.PortIds.IsNull() {
+		data.PortIds = helpers.GetStringSet(value.Array())
+	} else {
+		data.PortIds = types.SetNull(types.StringType)
+	}
 		(*parent).AssignedSwitchPorts[i] = data
 	}
 	for i := 0; i < len(data.Rules); i++ {
-		keys := [...]string{"priority"}
-		keyValues := [...]string{strconv.FormatInt(data.Rules[i].Priority.ValueInt64(), 10)}
+		keys := [...]string{ "priority",  }
+		keyValues := [...]string{ strconv.FormatInt(data.Rules[i].Priority.ValueInt64(), 10),  }
 
 		parent := &data
 		data := (*parent).Rules[i]
@@ -347,69 +380,69 @@ func (data *SwitchOrganizationPortsProfilesAutomation) fromBodyPartial(ctx conte
 
 			continue
 		}
-		if value := res.Get("priority"); value.Exists() && !data.Priority.IsNull() {
-			data.Priority = types.Int64Value(value.Int())
-		} else {
-			data.Priority = types.Int64Null()
-		}
-		if value := res.Get("profile.id"); value.Exists() && !data.ProfileId.IsNull() {
-			data.ProfileId = types.StringValue(value.String())
-		} else {
-			data.ProfileId = types.StringNull()
-		}
-		if value := res.Get("profile.name"); value.Exists() && !data.ProfileName.IsNull() {
-			data.ProfileName = types.StringValue(value.String())
-		} else {
-			data.ProfileName = types.StringNull()
-		}
-		for i := 0; i < len(data.Conditions); i++ {
-			keys := [...]string{"attribute"}
-			keyValues := [...]string{data.Conditions[i].Attribute.ValueString()}
+	if value := res.Get("priority"); value.Exists() && !data.Priority.IsNull() {
+		data.Priority = types.Int64Value(value.Int())
+	} else {
+		data.Priority = types.Int64Null()
+	}
+	if value := res.Get("profile.id"); value.Exists() && !data.ProfileId.IsNull() {
+		data.ProfileId = types.StringValue(value.String())
+	} else {
+		data.ProfileId = types.StringNull()
+	}
+	if value := res.Get("profile.name"); value.Exists() && !data.ProfileName.IsNull() {
+		data.ProfileName = types.StringValue(value.String())
+	} else {
+		data.ProfileName = types.StringNull()
+	}
+	for i := 0; i < len(data.Conditions); i++ {
+		keys := [...]string{ "attribute",  }
+		keyValues := [...]string{ data.Conditions[i].Attribute.ValueString(),  }
 
-			parent := &data
-			data := (*parent).Conditions[i]
-			parentRes := &res
-			var res gjson.Result
+		parent := &data
+		data := (*parent).Conditions[i]
+		parentRes := &res
+		var res gjson.Result
 
-			parentRes.Get("conditions").ForEach(
-				func(_, v gjson.Result) bool {
-					found := false
-					for ik := range keys {
-						if v.Get(keys[ik]).String() != keyValues[ik] {
-							found = false
-							break
-						}
-						found = true
+		parentRes.Get("conditions").ForEach(
+			func(_, v gjson.Result) bool {
+				found := false
+				for ik := range keys {
+					if v.Get(keys[ik]).String() != keyValues[ik] {
+						found = false
+						break
 					}
-					if found {
-						res = v
-						return false
-					}
-					return true
-				},
-			)
-			if !res.Exists() {
-				tflog.Debug(ctx, fmt.Sprintf("removing Conditions[%d] = %+v",
-					i,
-					(*parent).Conditions[i],
-				))
-				(*parent).Conditions = slices.Delete((*parent).Conditions, i, i+1)
-				i--
+					found = true
+				}
+				if found {
+					res = v
+					return false
+				}
+				return true
+			},
+		)
+		if !res.Exists() {
+			tflog.Debug(ctx, fmt.Sprintf("removing Conditions[%d] = %+v",
+				i,
+				(*parent).Conditions[i],
+			))
+			(*parent).Conditions = slices.Delete((*parent).Conditions, i, i+1)
+			i--
 
-				continue
-			}
-			if value := res.Get("attribute"); value.Exists() && !data.Attribute.IsNull() {
-				data.Attribute = types.StringValue(value.String())
-			} else {
-				data.Attribute = types.StringNull()
-			}
-			if value := res.Get("values"); value.Exists() && !data.Values.IsNull() {
-				data.Values = helpers.GetStringList(value.Array())
-			} else {
-				data.Values = types.ListNull(types.StringType)
-			}
-			(*parent).Conditions[i] = data
+			continue
 		}
+	if value := res.Get("attribute"); value.Exists() && !data.Attribute.IsNull() {
+		data.Attribute = types.StringValue(value.String())
+	} else {
+		data.Attribute = types.StringNull()
+	}
+	if value := res.Get("values"); value.Exists() && !data.Values.IsNull() {
+		data.Values = helpers.GetStringList(value.Array())
+	} else {
+		data.Values = types.ListNull(types.StringType)
+	}
+		(*parent).Conditions[i] = data
+	}
 		(*parent).Rules[i] = data
 	}
 }
@@ -431,7 +464,7 @@ func (data *SwitchOrganizationPortsProfilesAutomationIdentity) toIdentity(ctx co
 	data.OrganizationId = plan.OrganizationId
 	data.Id = plan.Id
 }
-
+	
 // End of section. //template:end toIdentity
 
 // Section below is generated&owned by "gen/generator.go". //template:begin fromIdentity
@@ -440,7 +473,7 @@ func (data *SwitchOrganizationPortsProfilesAutomation) fromIdentity(ctx context.
 	data.OrganizationId = identity.OrganizationId
 	data.Id = identity.Id
 }
-
+	
 // End of section. //template:end fromIdentity
 
 // Section below is generated&owned by "gen/generator.go". //template:begin toDestroyBody

--- a/internal/provider/model_resource_meraki_switch_organization_ports_profiles_automation.go
+++ b/internal/provider/model_resource_meraki_switch_organization_ports_profiles_automation.go
@@ -38,65 +38,36 @@ import (
 // Section below is generated&owned by "gen/generator.go". //template:begin types
 
 type SwitchOrganizationPortsProfilesAutomation struct {
-	Id types.String `tfsdk:"id"`
-	OrganizationId types.String `tfsdk:"organization_id"`
-	Description types.String `tfsdk:"description"`
-	Name types.String `tfsdk:"name"`
-	FallbackProfileId types.String `tfsdk:"fallback_profile_id"`
-	FallbackProfileName types.String `tfsdk:"fallback_profile_name"`
+	Id                  types.String                                                   `tfsdk:"id"`
+	OrganizationId      types.String                                                   `tfsdk:"organization_id"`
+	Description         types.String                                                   `tfsdk:"description"`
+	Name                types.String                                                   `tfsdk:"name"`
+	FallbackProfileId   types.String                                                   `tfsdk:"fallback_profile_id"`
+	FallbackProfileName types.String                                                   `tfsdk:"fallback_profile_name"`
 	AssignedSwitchPorts []SwitchOrganizationPortsProfilesAutomationAssignedSwitchPorts `tfsdk:"assigned_switch_ports"`
-	Rules []SwitchOrganizationPortsProfilesAutomationRules `tfsdk:"rules"`
+	Rules               []SwitchOrganizationPortsProfilesAutomationRules               `tfsdk:"rules"`
 }
-
-
-
-
-
-
 
 type SwitchOrganizationPortsProfilesAutomationAssignedSwitchPorts struct {
 	SwitchSerial types.String `tfsdk:"switch_serial"`
-	PortIds types.Set `tfsdk:"port_ids"`
+	PortIds      types.Set    `tfsdk:"port_ids"`
 }
 
 type SwitchOrganizationPortsProfilesAutomationRules struct {
-	Priority types.Int64 `tfsdk:"priority"`
-	ProfileId types.String `tfsdk:"profile_id"`
-	ProfileName types.String `tfsdk:"profile_name"`
-	Conditions []SwitchOrganizationPortsProfilesAutomationRulesConditions `tfsdk:"conditions"`
+	Priority    types.Int64                                                `tfsdk:"priority"`
+	ProfileId   types.String                                               `tfsdk:"profile_id"`
+	ProfileName types.String                                               `tfsdk:"profile_name"`
+	Conditions  []SwitchOrganizationPortsProfilesAutomationRulesConditions `tfsdk:"conditions"`
 }
-
-
-
-
-
-
-
-
-
-
 
 type SwitchOrganizationPortsProfilesAutomationRulesConditions struct {
 	Attribute types.String `tfsdk:"attribute"`
-	Values types.List `tfsdk:"values"`
+	Values    types.List   `tfsdk:"values"`
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 type SwitchOrganizationPortsProfilesAutomationIdentity struct {
 	OrganizationId types.String `tfsdk:"organization_id"`
-	Id types.String `tfsdk:"id"`
+	Id             types.String `tfsdk:"id"`
 }
 
 // End of section. //template:end types
@@ -104,7 +75,7 @@ type SwitchOrganizationPortsProfilesAutomationIdentity struct {
 // Section below is generated&owned by "gen/generator.go". //template:begin getPath
 
 func (data SwitchOrganizationPortsProfilesAutomation) getPath() string {
-		return fmt.Sprintf("/organizations/%v/switch/ports/profiles/automations", url.QueryEscape(data.OrganizationId.ValueString()))
+	return fmt.Sprintf("/organizations/%v/switch/ports/profiles/automations", url.QueryEscape(data.OrganizationId.ValueString()))
 }
 
 // End of section. //template:end getPath
@@ -113,18 +84,18 @@ func (data SwitchOrganizationPortsProfilesAutomation) getPath() string {
 
 func (data SwitchOrganizationPortsProfilesAutomation) toBody(ctx context.Context, state SwitchOrganizationPortsProfilesAutomation) string {
 	body := ""
-	if !data.Description.IsNull()  {
+	if !data.Description.IsNull() {
 		body, _ = sjson.Set(body, "description", data.Description.ValueString())
 	}
-	if !data.Name.IsNull()  {
+	if !data.Name.IsNull() {
 		body, _ = sjson.Set(body, "name", data.Name.ValueString())
 	}
-	if !data.FallbackProfileId.IsNull()  {
+	if !data.FallbackProfileId.IsNull() {
 		body, _ = sjson.Set(body, "fallbackProfile.id", data.FallbackProfileId.ValueString())
 	} else if !state.FallbackProfileId.IsNull() {
 		body, _ = sjson.Set(body, "fallbackProfile.id", nil)
 	}
-	if !data.FallbackProfileName.IsNull()  {
+	if !data.FallbackProfileName.IsNull() {
 		body, _ = sjson.Set(body, "fallbackProfile.name", data.FallbackProfileName.ValueString())
 	} else if !state.FallbackProfileName.IsNull() {
 		body, _ = sjson.Set(body, "fallbackProfile.name", nil)
@@ -208,16 +179,16 @@ func (data *SwitchOrganizationPortsProfilesAutomation) fromBody(ctx context.Cont
 		value.ForEach(func(k, res gjson.Result) bool {
 			parent := &data
 			data := SwitchOrganizationPortsProfilesAutomationAssignedSwitchPorts{}
-	if value := res.Get("switch.serial"); value.Exists() && value.Value() != nil {
-		data.SwitchSerial = types.StringValue(value.String())
-	} else {
-		data.SwitchSerial = types.StringNull()
-	}
-	if value := res.Get("portIds"); value.Exists() && value.Value() != nil {
-		data.PortIds = helpers.GetStringSet(value.Array())
-	} else {
-		data.PortIds = types.SetNull(types.StringType)
-	}
+			if value := res.Get("switch.serial"); value.Exists() && value.Value() != nil {
+				data.SwitchSerial = types.StringValue(value.String())
+			} else {
+				data.SwitchSerial = types.StringNull()
+			}
+			if value := res.Get("portIds"); value.Exists() && value.Value() != nil {
+				data.PortIds = helpers.GetStringSet(value.Array())
+			} else {
+				data.PortIds = types.SetNull(types.StringType)
+			}
 			(*parent).AssignedSwitchPorts = append((*parent).AssignedSwitchPorts, data)
 			return true
 		})
@@ -227,40 +198,40 @@ func (data *SwitchOrganizationPortsProfilesAutomation) fromBody(ctx context.Cont
 		value.ForEach(func(k, res gjson.Result) bool {
 			parent := &data
 			data := SwitchOrganizationPortsProfilesAutomationRules{}
-	if value := res.Get("priority"); value.Exists() && value.Value() != nil {
-		data.Priority = types.Int64Value(value.Int())
-	} else {
-		data.Priority = types.Int64Null()
-	}
-	if value := res.Get("profile.id"); value.Exists() && value.Value() != nil {
-		data.ProfileId = types.StringValue(value.String())
-	} else {
-		data.ProfileId = types.StringNull()
-	}
-	if value := res.Get("profile.name"); value.Exists() && value.Value() != nil {
-		data.ProfileName = types.StringValue(value.String())
-	} else {
-		data.ProfileName = types.StringNull()
-	}
-	if value := res.Get("conditions"); value.Exists() && value.Value() != nil {
-		data.Conditions = make([]SwitchOrganizationPortsProfilesAutomationRulesConditions, 0)
-		value.ForEach(func(k, res gjson.Result) bool {
-			parent := &data
-			data := SwitchOrganizationPortsProfilesAutomationRulesConditions{}
-	if value := res.Get("attribute"); value.Exists() && value.Value() != nil {
-		data.Attribute = types.StringValue(value.String())
-	} else {
-		data.Attribute = types.StringNull()
-	}
-	if value := res.Get("values"); value.Exists() && value.Value() != nil {
-		data.Values = helpers.GetStringList(value.Array())
-	} else {
-		data.Values = types.ListNull(types.StringType)
-	}
-			(*parent).Conditions = append((*parent).Conditions, data)
-			return true
-		})
-	}
+			if value := res.Get("priority"); value.Exists() && value.Value() != nil {
+				data.Priority = types.Int64Value(value.Int())
+			} else {
+				data.Priority = types.Int64Null()
+			}
+			if value := res.Get("profile.id"); value.Exists() && value.Value() != nil {
+				data.ProfileId = types.StringValue(value.String())
+			} else {
+				data.ProfileId = types.StringNull()
+			}
+			if value := res.Get("profile.name"); value.Exists() && value.Value() != nil {
+				data.ProfileName = types.StringValue(value.String())
+			} else {
+				data.ProfileName = types.StringNull()
+			}
+			if value := res.Get("conditions"); value.Exists() && value.Value() != nil {
+				data.Conditions = make([]SwitchOrganizationPortsProfilesAutomationRulesConditions, 0)
+				value.ForEach(func(k, res gjson.Result) bool {
+					parent := &data
+					data := SwitchOrganizationPortsProfilesAutomationRulesConditions{}
+					if value := res.Get("attribute"); value.Exists() && value.Value() != nil {
+						data.Attribute = types.StringValue(value.String())
+					} else {
+						data.Attribute = types.StringNull()
+					}
+					if value := res.Get("values"); value.Exists() && value.Value() != nil {
+						data.Values = helpers.GetStringList(value.Array())
+					} else {
+						data.Values = types.ListNull(types.StringType)
+					}
+					(*parent).Conditions = append((*parent).Conditions, data)
+					return true
+				})
+			}
 			(*parent).Rules = append((*parent).Rules, data)
 			return true
 		})
@@ -297,8 +268,8 @@ func (data *SwitchOrganizationPortsProfilesAutomation) fromBodyPartial(ctx conte
 		data.FallbackProfileName = types.StringNull()
 	}
 	for i := 0; i < len(data.AssignedSwitchPorts); i++ {
-		keys := [...]string{ "switch.serial",  }
-		keyValues := [...]string{ data.AssignedSwitchPorts[i].SwitchSerial.ValueString(),  }
+		keys := [...]string{"switch.serial"}
+		keyValues := [...]string{data.AssignedSwitchPorts[i].SwitchSerial.ValueString()}
 
 		parent := &data
 		data := (*parent).AssignedSwitchPorts[i]
@@ -332,21 +303,21 @@ func (data *SwitchOrganizationPortsProfilesAutomation) fromBodyPartial(ctx conte
 
 			continue
 		}
-	if value := res.Get("switch.serial"); value.Exists() && !data.SwitchSerial.IsNull() {
-		data.SwitchSerial = types.StringValue(value.String())
-	} else {
-		data.SwitchSerial = types.StringNull()
-	}
-	if value := res.Get("portIds"); value.Exists() && !data.PortIds.IsNull() {
-		data.PortIds = helpers.GetStringSet(value.Array())
-	} else {
-		data.PortIds = types.SetNull(types.StringType)
-	}
+		if value := res.Get("switch.serial"); value.Exists() && !data.SwitchSerial.IsNull() {
+			data.SwitchSerial = types.StringValue(value.String())
+		} else {
+			data.SwitchSerial = types.StringNull()
+		}
+		if value := res.Get("portIds"); value.Exists() && !data.PortIds.IsNull() {
+			data.PortIds = helpers.GetStringSet(value.Array())
+		} else {
+			data.PortIds = types.SetNull(types.StringType)
+		}
 		(*parent).AssignedSwitchPorts[i] = data
 	}
 	for i := 0; i < len(data.Rules); i++ {
-		keys := [...]string{ "priority",  }
-		keyValues := [...]string{ strconv.FormatInt(data.Rules[i].Priority.ValueInt64(), 10),  }
+		keys := [...]string{"priority"}
+		keyValues := [...]string{strconv.FormatInt(data.Rules[i].Priority.ValueInt64(), 10)}
 
 		parent := &data
 		data := (*parent).Rules[i]
@@ -380,69 +351,69 @@ func (data *SwitchOrganizationPortsProfilesAutomation) fromBodyPartial(ctx conte
 
 			continue
 		}
-	if value := res.Get("priority"); value.Exists() && !data.Priority.IsNull() {
-		data.Priority = types.Int64Value(value.Int())
-	} else {
-		data.Priority = types.Int64Null()
-	}
-	if value := res.Get("profile.id"); value.Exists() && !data.ProfileId.IsNull() {
-		data.ProfileId = types.StringValue(value.String())
-	} else {
-		data.ProfileId = types.StringNull()
-	}
-	if value := res.Get("profile.name"); value.Exists() && !data.ProfileName.IsNull() {
-		data.ProfileName = types.StringValue(value.String())
-	} else {
-		data.ProfileName = types.StringNull()
-	}
-	for i := 0; i < len(data.Conditions); i++ {
-		keys := [...]string{ "attribute",  }
-		keyValues := [...]string{ data.Conditions[i].Attribute.ValueString(),  }
-
-		parent := &data
-		data := (*parent).Conditions[i]
-		parentRes := &res
-		var res gjson.Result
-
-		parentRes.Get("conditions").ForEach(
-			func(_, v gjson.Result) bool {
-				found := false
-				for ik := range keys {
-					if v.Get(keys[ik]).String() != keyValues[ik] {
-						found = false
-						break
-					}
-					found = true
-				}
-				if found {
-					res = v
-					return false
-				}
-				return true
-			},
-		)
-		if !res.Exists() {
-			tflog.Debug(ctx, fmt.Sprintf("removing Conditions[%d] = %+v",
-				i,
-				(*parent).Conditions[i],
-			))
-			(*parent).Conditions = slices.Delete((*parent).Conditions, i, i+1)
-			i--
-
-			continue
+		if value := res.Get("priority"); value.Exists() && !data.Priority.IsNull() {
+			data.Priority = types.Int64Value(value.Int())
+		} else {
+			data.Priority = types.Int64Null()
 		}
-	if value := res.Get("attribute"); value.Exists() && !data.Attribute.IsNull() {
-		data.Attribute = types.StringValue(value.String())
-	} else {
-		data.Attribute = types.StringNull()
-	}
-	if value := res.Get("values"); value.Exists() && !data.Values.IsNull() {
-		data.Values = helpers.GetStringList(value.Array())
-	} else {
-		data.Values = types.ListNull(types.StringType)
-	}
-		(*parent).Conditions[i] = data
-	}
+		if value := res.Get("profile.id"); value.Exists() && !data.ProfileId.IsNull() {
+			data.ProfileId = types.StringValue(value.String())
+		} else {
+			data.ProfileId = types.StringNull()
+		}
+		if value := res.Get("profile.name"); value.Exists() && !data.ProfileName.IsNull() {
+			data.ProfileName = types.StringValue(value.String())
+		} else {
+			data.ProfileName = types.StringNull()
+		}
+		for i := 0; i < len(data.Conditions); i++ {
+			keys := [...]string{"attribute"}
+			keyValues := [...]string{data.Conditions[i].Attribute.ValueString()}
+
+			parent := &data
+			data := (*parent).Conditions[i]
+			parentRes := &res
+			var res gjson.Result
+
+			parentRes.Get("conditions").ForEach(
+				func(_, v gjson.Result) bool {
+					found := false
+					for ik := range keys {
+						if v.Get(keys[ik]).String() != keyValues[ik] {
+							found = false
+							break
+						}
+						found = true
+					}
+					if found {
+						res = v
+						return false
+					}
+					return true
+				},
+			)
+			if !res.Exists() {
+				tflog.Debug(ctx, fmt.Sprintf("removing Conditions[%d] = %+v",
+					i,
+					(*parent).Conditions[i],
+				))
+				(*parent).Conditions = slices.Delete((*parent).Conditions, i, i+1)
+				i--
+
+				continue
+			}
+			if value := res.Get("attribute"); value.Exists() && !data.Attribute.IsNull() {
+				data.Attribute = types.StringValue(value.String())
+			} else {
+				data.Attribute = types.StringNull()
+			}
+			if value := res.Get("values"); value.Exists() && !data.Values.IsNull() {
+				data.Values = helpers.GetStringList(value.Array())
+			} else {
+				data.Values = types.ListNull(types.StringType)
+			}
+			(*parent).Conditions[i] = data
+		}
 		(*parent).Rules[i] = data
 	}
 }
@@ -464,7 +435,7 @@ func (data *SwitchOrganizationPortsProfilesAutomationIdentity) toIdentity(ctx co
 	data.OrganizationId = plan.OrganizationId
 	data.Id = plan.Id
 }
-	
+
 // End of section. //template:end toIdentity
 
 // Section below is generated&owned by "gen/generator.go". //template:begin fromIdentity
@@ -473,7 +444,7 @@ func (data *SwitchOrganizationPortsProfilesAutomation) fromIdentity(ctx context.
 	data.OrganizationId = identity.OrganizationId
 	data.Id = identity.Id
 }
-	
+
 // End of section. //template:end fromIdentity
 
 // Section below is generated&owned by "gen/generator.go". //template:begin toDestroyBody

--- a/internal/provider/resource_meraki_switch_organization_ports_profiles_automation.go
+++ b/internal/provider/resource_meraki_switch_organization_ports_profiles_automation.go
@@ -106,7 +106,7 @@ func (r *SwitchOrganizationPortsProfilesAutomationResource) Schema(ctx context.C
 							MarkdownDescription: helpers.NewAttributeDescription("Serial number of the switch").String,
 							Optional:            true,
 						},
-						"port_ids": schema.ListAttribute{
+						"port_ids": schema.SetAttribute{
 							MarkdownDescription: helpers.NewAttributeDescription("List of port ids").String,
 							ElementType:         types.StringType,
 							Optional:            true,

--- a/internal/provider/resource_meraki_switch_organization_ports_profiles_automation_test.go
+++ b/internal/provider/resource_meraki_switch_organization_ports_profiles_automation_test.go
@@ -40,7 +40,6 @@ func TestAccMerakiSwitchOrganizationPortsProfilesAutomation(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("meraki_switch_organization_ports_profiles_automation.test", "description", "A full length description of the automation."))
 	checks = append(checks, resource.TestCheckResourceAttr("meraki_switch_organization_ports_profiles_automation.test", "name", "Automation 1"))
-	checks = append(checks, resource.TestCheckResourceAttr("meraki_switch_organization_ports_profiles_automation.test", "assigned_switch_ports.0.port_ids.0", "3"))
 	checks = append(checks, resource.TestCheckResourceAttr("meraki_switch_organization_ports_profiles_automation.test", "rules.0.priority", "1"))
 	checks = append(checks, resource.TestCheckResourceAttr("meraki_switch_organization_ports_profiles_automation.test", "rules.0.conditions.0.attribute", "LLDP system description"))
 	checks = append(checks, resource.TestCheckResourceAttr("meraki_switch_organization_ports_profiles_automation.test", "rules.0.conditions.0.values.0", "Meraki MR*"))


### PR DESCRIPTION
Fixes two issues with the `meraki_switch_organization_ports_profiles_automation` resource.

## Changes

- Change `port_ids` from `ListAttribute` to `SetAttribute` so Terraform ignores API return order (fixes spurious diffs on re-plan)
- Explicitly send `null` for `fallbackProfile.id` / `fallbackProfile.name` when removed from config so the API clears the values
- Add `send_null_on_clear` generator property to anchor the fix in the definition YAML

## Related

- Module PR: https://github.com/netascode/terraform-meraki-nac-meraki/pull/188

## Test plan

- [ ] Apply automation with `fallback_profile_name` set, then remove it — verify API clears the value and plan shows no diff
- [ ] Apply automation with port ranges — verify re-plan shows no diff (port_ids idempotent)