### PR TITLE
appliance_static_route: Add enabled attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add `meraki_reboot_device` action
 - Add `meraki_blink_device_leds` action
 - Fix issue with `spare_serial` attribute of `meraki_appliance_warm_spare` resource, [link](https://github.com/CiscoDevNet/terraform-provider-meraki/issues/256)
+- Add `enabled` attribute to `meraki_appliance_static_route` resource and data source, [link](https://github.com/CiscoDevNet/terraform-provider-meraki/pull/269)
 
 ## 1.13.0
 

--- a/docs/data-sources/appliance_static_route.md
+++ b/docs/data-sources/appliance_static_route.md
@@ -33,6 +33,7 @@ data "meraki_appliance_static_route" "example" {
 
 ### Read-Only
 
+- `enabled` (Boolean) Enable/disable the static route
 - `gateway_ip` (String) Gateway IP address (next hop)
-- `gateway_vlan_id` (String) Gateway VLAN ID
+- `gateway_vlan_id` (Number) Gateway VLAN ID
 - `subnet` (String) Subnet of the route

--- a/docs/data-sources/appliance_static_routes.md
+++ b/docs/data-sources/appliance_static_routes.md
@@ -34,8 +34,9 @@ data "meraki_appliance_static_routes" "example" {
 
 Read-Only:
 
+- `enabled` (Boolean) Enable/disable the static route
 - `gateway_ip` (String) Gateway IP address (next hop)
-- `gateway_vlan_id` (String) Gateway VLAN ID
+- `gateway_vlan_id` (Number) Gateway VLAN ID
 - `id` (String) The id of the object
 - `name` (String) Name of the route
 - `subnet` (String) Subnet of the route

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -13,6 +13,7 @@ description: |-
 - Add `meraki_reboot_device` action
 - Add `meraki_blink_device_leds` action
 - Fix issue with `spare_serial` attribute of `meraki_appliance_warm_spare` resource, [link](https://github.com/CiscoDevNet/terraform-provider-meraki/issues/256)
+- Add `enabled` attribute to `meraki_appliance_static_route` resource and data source, [link](https://github.com/CiscoDevNet/terraform-provider-meraki/pull/269)
 
 ## 1.13.0
 

--- a/docs/resources/appliance_static_route.md
+++ b/docs/resources/appliance_static_route.md
@@ -14,10 +14,12 @@ This resource can manage the `Appliance Static Route` configuration.
 
 ```terraform
 resource "meraki_appliance_static_route" "example" {
-  network_id = "L_123456"
-  gateway_ip = "192.168.128.254"
-  name       = "My route"
-  subnet     = "5.5.5.0/24"
+  network_id      = "L_123456"
+  enabled         = true
+  gateway_ip      = "192.168.128.254"
+  gateway_vlan_id = 100
+  name            = "My route"
+  subnet          = "5.5.5.0/24"
 }
 ```
 
@@ -33,7 +35,9 @@ resource "meraki_appliance_static_route" "example" {
 
 ### Optional
 
-- `gateway_vlan_id` (String) Gateway VLAN ID
+- `enabled` (Boolean) Enable/disable the static route
+- `gateway_vlan_id` (Number) Gateway VLAN ID
+  - Range: `0`-`4094`
 
 ### Read-Only
 

--- a/examples/resources/meraki_appliance_static_route/resource.tf
+++ b/examples/resources/meraki_appliance_static_route/resource.tf
@@ -1,6 +1,8 @@
 resource "meraki_appliance_static_route" "example" {
-  network_id = "L_123456"
-  gateway_ip = "192.168.128.254"
-  name       = "My route"
-  subnet     = "5.5.5.0/24"
+  network_id      = "L_123456"
+  enabled         = true
+  gateway_ip      = "192.168.128.254"
+  gateway_vlan_id = 100
+  name            = "My route"
+  subnet          = "5.5.5.0/24"
 }

--- a/gen/definitions/appliance_static_route.yaml
+++ b/gen/definitions/appliance_static_route.yaml
@@ -12,16 +12,21 @@ attributes:
     description: Network ID
     example: L_123456
     test_value: meraki_network.test.id
+  - model_name: enabled
+    type: Bool
+    description: Enable/disable the static route
+    example: "true"
   - model_name: gatewayIp
     type: String
     mandatory: true
     description: Gateway IP address (next hop)
     example: 192.168.128.254
   - model_name: gatewayVlanId
-    type: String
-    exclude_test: true
+    type: Int64
     description: Gateway VLAN ID
     example: "100"
+    min_int: 0
+    max_int: 4094
   - model_name: name
     type: String
     mandatory: true

--- a/gen/load_models.go
+++ b/gen/load_models.go
@@ -62,6 +62,10 @@ func downloadModel(filepath string, url string) error {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("Failed to download model (%s): HTTP %s", url, resp.Status)
+	}
+
 	out, err := os.Create(filepath)
 	if err != nil {
 		return err

--- a/internal/provider/data_source_meraki_appliance_static_route.go
+++ b/internal/provider/data_source_meraki_appliance_static_route.go
@@ -71,11 +71,15 @@ func (d *ApplianceStaticRouteDataSource) Schema(ctx context.Context, req datasou
 				MarkdownDescription: "Network ID",
 				Required:            true,
 			},
+			"enabled": schema.BoolAttribute{
+				MarkdownDescription: "Enable/disable the static route",
+				Computed:            true,
+			},
 			"gateway_ip": schema.StringAttribute{
 				MarkdownDescription: "Gateway IP address (next hop)",
 				Computed:            true,
 			},
-			"gateway_vlan_id": schema.StringAttribute{
+			"gateway_vlan_id": schema.Int64Attribute{
 				MarkdownDescription: "Gateway VLAN ID",
 				Computed:            true,
 			},

--- a/internal/provider/data_source_meraki_appliance_static_route_test.go
+++ b/internal/provider/data_source_meraki_appliance_static_route_test.go
@@ -34,7 +34,9 @@ func TestAccDataSourceMerakiApplianceStaticRoute(t *testing.T) {
 		t.Skip("skipping test, set environment variable TF_VAR_test_org and TF_VAR_test_network")
 	}
 	var checks []resource.TestCheckFunc
+	checks = append(checks, resource.TestCheckResourceAttr("data.meraki_appliance_static_route.test", "enabled", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.meraki_appliance_static_route.test", "gateway_ip", "192.168.128.254"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.meraki_appliance_static_route.test", "gateway_vlan_id", "100"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.meraki_appliance_static_route.test", "name", "My route"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.meraki_appliance_static_route.test", "subnet", "5.5.5.0/24"))
 	resource.Test(t, resource.TestCase{
@@ -74,7 +76,9 @@ resource "meraki_network" "test" {
 func testAccDataSourceMerakiApplianceStaticRouteConfig() string {
 	config := `resource "meraki_appliance_static_route" "test" {` + "\n"
 	config += `  network_id = meraki_network.test.id` + "\n"
+	config += `  enabled = true` + "\n"
 	config += `  gateway_ip = "192.168.128.254"` + "\n"
+	config += `  gateway_vlan_id = 100` + "\n"
 	config += `  name = "My route"` + "\n"
 	config += `  subnet = "5.5.5.0/24"` + "\n"
 	config += `}` + "\n"
@@ -92,7 +96,9 @@ func testAccDataSourceMerakiApplianceStaticRouteConfig() string {
 func testAccNamedDataSourceMerakiApplianceStaticRouteConfig() string {
 	config := `resource "meraki_appliance_static_route" "test" {` + "\n"
 	config += `  network_id = meraki_network.test.id` + "\n"
+	config += `  enabled = true` + "\n"
 	config += `  gateway_ip = "192.168.128.254"` + "\n"
+	config += `  gateway_vlan_id = 100` + "\n"
 	config += `  name = "My route"` + "\n"
 	config += `  subnet = "5.5.5.0/24"` + "\n"
 	config += `}` + "\n"

--- a/internal/provider/data_source_meraki_appliance_static_routes.go
+++ b/internal/provider/data_source_meraki_appliance_static_routes.go
@@ -70,11 +70,15 @@ func (d *ApplianceStaticRoutesDataSource) Schema(ctx context.Context, req dataso
 							MarkdownDescription: "The id of the object",
 							Computed:            true,
 						},
+						"enabled": schema.BoolAttribute{
+							MarkdownDescription: "Enable/disable the static route",
+							Computed:            true,
+						},
 						"gateway_ip": schema.StringAttribute{
 							MarkdownDescription: "Gateway IP address (next hop)",
 							Computed:            true,
 						},
-						"gateway_vlan_id": schema.StringAttribute{
+						"gateway_vlan_id": schema.Int64Attribute{
 							MarkdownDescription: "Gateway VLAN ID",
 							Computed:            true,
 						},

--- a/internal/provider/model_data_source_meraki_appliance_static_route.go
+++ b/internal/provider/model_data_source_meraki_appliance_static_route.go
@@ -42,8 +42,9 @@ import (
 type DataSourceApplianceStaticRoute struct {
 	Id            types.String `tfsdk:"id"`
 	NetworkId     types.String `tfsdk:"network_id"`
+	Enabled       types.Bool   `tfsdk:"enabled"`
 	GatewayIp     types.String `tfsdk:"gateway_ip"`
-	GatewayVlanId types.String `tfsdk:"gateway_vlan_id"`
+	GatewayVlanId types.Int64  `tfsdk:"gateway_vlan_id"`
 	Name          types.String `tfsdk:"name"`
 	Subnet        types.String `tfsdk:"subnet"`
 }
@@ -61,15 +62,20 @@ func (data DataSourceApplianceStaticRoute) getPath() string {
 // Section below is generated&owned by "gen/generator.go". //template:begin fromBody
 
 func (data *DataSourceApplianceStaticRoute) fromBody(ctx context.Context, res meraki.Res) {
+	if value := res.Get("enabled"); value.Exists() && value.Value() != nil {
+		data.Enabled = types.BoolValue(value.Bool())
+	} else {
+		data.Enabled = types.BoolNull()
+	}
 	if value := res.Get("gatewayIp"); value.Exists() && value.Value() != nil {
 		data.GatewayIp = types.StringValue(value.String())
 	} else {
 		data.GatewayIp = types.StringNull()
 	}
 	if value := res.Get("gatewayVlanId"); value.Exists() && value.Value() != nil {
-		data.GatewayVlanId = types.StringValue(value.String())
+		data.GatewayVlanId = types.Int64Value(value.Int())
 	} else {
-		data.GatewayVlanId = types.StringNull()
+		data.GatewayVlanId = types.Int64Null()
 	}
 	if value := res.Get("name"); value.Exists() && value.Value() != nil {
 		data.Name = types.StringValue(value.String())

--- a/internal/provider/model_data_source_meraki_appliance_static_routes.go
+++ b/internal/provider/model_data_source_meraki_appliance_static_routes.go
@@ -39,8 +39,9 @@ type DataSourceApplianceStaticRoutes struct {
 
 type DataSourceApplianceStaticRoutesItems struct {
 	Id            types.String `tfsdk:"id"`
+	Enabled       types.Bool   `tfsdk:"enabled"`
 	GatewayIp     types.String `tfsdk:"gateway_ip"`
-	GatewayVlanId types.String `tfsdk:"gateway_vlan_id"`
+	GatewayVlanId types.Int64  `tfsdk:"gateway_vlan_id"`
 	Name          types.String `tfsdk:"name"`
 	Subnet        types.String `tfsdk:"subnet"`
 }
@@ -63,15 +64,20 @@ func (data *DataSourceApplianceStaticRoutes) fromBody(ctx context.Context, res m
 		parent := &data
 		data := DataSourceApplianceStaticRoutesItems{}
 		data.Id = types.StringValue(res.Get("id").String())
+		if value := res.Get("enabled"); value.Exists() && value.Value() != nil {
+			data.Enabled = types.BoolValue(value.Bool())
+		} else {
+			data.Enabled = types.BoolNull()
+		}
 		if value := res.Get("gatewayIp"); value.Exists() && value.Value() != nil {
 			data.GatewayIp = types.StringValue(value.String())
 		} else {
 			data.GatewayIp = types.StringNull()
 		}
 		if value := res.Get("gatewayVlanId"); value.Exists() && value.Value() != nil {
-			data.GatewayVlanId = types.StringValue(value.String())
+			data.GatewayVlanId = types.Int64Value(value.Int())
 		} else {
-			data.GatewayVlanId = types.StringNull()
+			data.GatewayVlanId = types.Int64Null()
 		}
 		if value := res.Get("name"); value.Exists() && value.Value() != nil {
 			data.Name = types.StringValue(value.String())

--- a/internal/provider/model_resource_meraki_appliance_static_route.go
+++ b/internal/provider/model_resource_meraki_appliance_static_route.go
@@ -35,8 +35,9 @@ import (
 type ApplianceStaticRoute struct {
 	Id            types.String `tfsdk:"id"`
 	NetworkId     types.String `tfsdk:"network_id"`
+	Enabled       types.Bool   `tfsdk:"enabled"`
 	GatewayIp     types.String `tfsdk:"gateway_ip"`
-	GatewayVlanId types.String `tfsdk:"gateway_vlan_id"`
+	GatewayVlanId types.Int64  `tfsdk:"gateway_vlan_id"`
 	Name          types.String `tfsdk:"name"`
 	Subnet        types.String `tfsdk:"subnet"`
 }
@@ -60,11 +61,14 @@ func (data ApplianceStaticRoute) getPath() string {
 
 func (data ApplianceStaticRoute) toBody(ctx context.Context, state ApplianceStaticRoute) string {
 	body := ""
+	if !data.Enabled.IsNull() {
+		body, _ = sjson.Set(body, "enabled", data.Enabled.ValueBool())
+	}
 	if !data.GatewayIp.IsNull() {
 		body, _ = sjson.Set(body, "gatewayIp", data.GatewayIp.ValueString())
 	}
 	if !data.GatewayVlanId.IsNull() {
-		body, _ = sjson.Set(body, "gatewayVlanId", data.GatewayVlanId.ValueString())
+		body, _ = sjson.Set(body, "gatewayVlanId", data.GatewayVlanId.ValueInt64())
 	}
 	if !data.Name.IsNull() {
 		body, _ = sjson.Set(body, "name", data.Name.ValueString())
@@ -80,15 +84,20 @@ func (data ApplianceStaticRoute) toBody(ctx context.Context, state ApplianceStat
 // Section below is generated&owned by "gen/generator.go". //template:begin fromBody
 
 func (data *ApplianceStaticRoute) fromBody(ctx context.Context, res meraki.Res) {
+	if value := res.Get("enabled"); value.Exists() && value.Value() != nil {
+		data.Enabled = types.BoolValue(value.Bool())
+	} else {
+		data.Enabled = types.BoolNull()
+	}
 	if value := res.Get("gatewayIp"); value.Exists() && value.Value() != nil {
 		data.GatewayIp = types.StringValue(value.String())
 	} else {
 		data.GatewayIp = types.StringNull()
 	}
 	if value := res.Get("gatewayVlanId"); value.Exists() && value.Value() != nil {
-		data.GatewayVlanId = types.StringValue(value.String())
+		data.GatewayVlanId = types.Int64Value(value.Int())
 	} else {
-		data.GatewayVlanId = types.StringNull()
+		data.GatewayVlanId = types.Int64Null()
 	}
 	if value := res.Get("name"); value.Exists() && value.Value() != nil {
 		data.Name = types.StringValue(value.String())
@@ -111,15 +120,20 @@ func (data *ApplianceStaticRoute) fromBody(ctx context.Context, res meraki.Res) 
 // easily change across versions of the backend API.) For List/Set/Map attributes, the func only updates the
 // "managed" elements, instead of all elements.
 func (data *ApplianceStaticRoute) fromBodyPartial(ctx context.Context, res meraki.Res) {
+	if value := res.Get("enabled"); value.Exists() && !data.Enabled.IsNull() {
+		data.Enabled = types.BoolValue(value.Bool())
+	} else {
+		data.Enabled = types.BoolNull()
+	}
 	if value := res.Get("gatewayIp"); value.Exists() && !data.GatewayIp.IsNull() {
 		data.GatewayIp = types.StringValue(value.String())
 	} else {
 		data.GatewayIp = types.StringNull()
 	}
 	if value := res.Get("gatewayVlanId"); value.Exists() && !data.GatewayVlanId.IsNull() {
-		data.GatewayVlanId = types.StringValue(value.String())
+		data.GatewayVlanId = types.Int64Value(value.Int())
 	} else {
-		data.GatewayVlanId = types.StringNull()
+		data.GatewayVlanId = types.Int64Null()
 	}
 	if value := res.Get("name"); value.Exists() && !data.Name.IsNull() {
 		data.Name = types.StringValue(value.String())

--- a/internal/provider/resource_meraki_appliance_static_route.go
+++ b/internal/provider/resource_meraki_appliance_static_route.go
@@ -25,12 +25,14 @@ import (
 	"strings"
 
 	"github.com/CiscoDevNet/terraform-provider-meraki/internal/provider/helpers"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/identityschema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/netascode/go-meraki"
@@ -78,13 +80,20 @@ func (r *ApplianceStaticRouteResource) Schema(ctx context.Context, req resource.
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"enabled": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enable/disable the static route").String,
+				Optional:            true,
+			},
 			"gateway_ip": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Gateway IP address (next hop)").String,
 				Required:            true,
 			},
-			"gateway_vlan_id": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Gateway VLAN ID").String,
+			"gateway_vlan_id": schema.Int64Attribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Gateway VLAN ID").AddIntegerRangeDescription(0, 4094).String,
 				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(0, 4094),
+				},
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Name of the route").String,

--- a/internal/provider/resource_meraki_appliance_static_route_test.go
+++ b/internal/provider/resource_meraki_appliance_static_route_test.go
@@ -38,7 +38,9 @@ func TestAccMerakiApplianceStaticRoute(t *testing.T) {
 		t.Skip("skipping test, set environment variable TF_VAR_test_org and TF_VAR_test_network")
 	}
 	var checks []resource.TestCheckFunc
+	checks = append(checks, resource.TestCheckResourceAttr("meraki_appliance_static_route.test", "enabled", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("meraki_appliance_static_route.test", "gateway_ip", "192.168.128.254"))
+	checks = append(checks, resource.TestCheckResourceAttr("meraki_appliance_static_route.test", "gateway_vlan_id", "100"))
 	checks = append(checks, resource.TestCheckResourceAttr("meraki_appliance_static_route.test", "name", "My route"))
 	checks = append(checks, resource.TestCheckResourceAttr("meraki_appliance_static_route.test", "subnet", "5.5.5.0/24"))
 
@@ -124,7 +126,9 @@ func testAccMerakiApplianceStaticRouteConfig_minimum() string {
 func testAccMerakiApplianceStaticRouteConfig_all() string {
 	config := `resource "meraki_appliance_static_route" "test" {` + "\n"
 	config += `  network_id = meraki_network.test.id` + "\n"
+	config += `  enabled = true` + "\n"
 	config += `  gateway_ip = "192.168.128.254"` + "\n"
+	config += `  gateway_vlan_id = 100` + "\n"
 	config += `  name = "My route"` + "\n"
 	config += `  subnet = "5.5.5.0/24"` + "\n"
 	config += `}` + "\n"

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -13,6 +13,7 @@ description: |-
 - Add `meraki_reboot_device` action
 - Add `meraki_blink_device_leds` action
 - Fix issue with `spare_serial` attribute of `meraki_appliance_warm_spare` resource, [link](https://github.com/CiscoDevNet/terraform-provider-meraki/issues/256)
+- Add `enabled` attribute to `meraki_appliance_static_route` resource and data source, [link](https://github.com/CiscoDevNet/terraform-provider-meraki/pull/269)
 
 ## 1.13.0
 


### PR DESCRIPTION
Added in OpenAPI spec v1.73.0.

Fixes #233

[appliance_static_route: Regenerate with v1.73.0](https://github.com/CiscoDevNet/terraform-provider-meraki/pull/269/commits/9fe66900618e2bc5604fd849b2cbd6cc0e5c32bd)
[9fe6690](https://github.com/CiscoDevNet/terraform-provider-meraki/pull/269/commits/9fe66900618e2bc5604fd849b2cbd6cc0e5c32bd)

Note: v1.70.0 has changed gatewayVlanId from a string to an int.
Just regenerating adds `min_int` and `max_int`
while keeping `type: String`, which fails to bulid:
```
internal/provider/resource_meraki_appliance_static_route.go:94:17: cannot use []validator.Int64{…} (value of type []validator.Int64) as []validator.String value in struct literal
```
Remove the field and regenerate to have the type changed to `Int64`.

This is backward compatible as Terraform implicitly converts strings to ints.

[downloadModel: Check HTTP status code](https://github.com/CiscoDevNet/terraform-provider-meraki/pull/269/commits/3fb431a1eff515c7f738cb5baa50db5e0e6fe4be)
[3fb431a](https://github.com/CiscoDevNet/terraform-provider-meraki/pull/269/commits/3fb431a1eff515c7f738cb5baa50db5e0e6fe4be)

When a model file is not already downloaded,
load_models downloads it, but does not check the status code.

During a Github outage, 429 was returned along with text
instead of the expected JSON. "make gen" then failed:

```
Downloaded model: gen/models/spec3.json
Downloaded model: gen/models/beta_spec3.json
go run ./gen/definition.go "/networks/{networkId}/appliance/staticRoutes/{staticRouteId}" "Appliance Static Route"
Error parsing OpenAPI spec: invalid character ':' after top-level value
exit status 1
make: *** [gen] Error 1
```

Check the status code to fail instead of downloading incorrect data.